### PR TITLE
Preselect ARC Adult CPR AED

### DIFF
--- a/data/config/block_schedule_pages.json
+++ b/data/config/block_schedule_pages.json
@@ -578,6 +578,7 @@
       "seated_class_minimum_enrollment": 1,
       "shared_cooldown_days_after_booking": 6,
       "shared_cooldown_minimum_enrollment": 1,
+      "default_course_id": "372258",
       "show_all_label": "Show all Red Cross course options",
       "compare_mode": {
         "enabled": false,

--- a/docs/arc.html
+++ b/docs/arc.html
@@ -587,7 +587,7 @@
     let availabilityState = 'checking';
     let availabilityMessage = 'Checking current class times…';
     let resolvedAvailability = null;
-    let selectedCourseId = "248288";
+    let selectedCourseId = "372258";
     let showAllOptions = false;
     let compareMode = false;
     let selectedDate = '';

--- a/scripts/build_bls_block_schedule_pilot.py
+++ b/scripts/build_bls_block_schedule_pilot.py
@@ -806,7 +806,13 @@ def render_html(payload: dict[str, Any]) -> str:
     ]
     unsupported_options_json = json.dumps(unsupported_options, ensure_ascii=False)
     counts = payload["counts"]
-    first_course = course_options[0]["courseId"] if course_options else ""
+    configured_default_course = str(page_config.get("default_course_id") or "").strip()
+    available_course_ids = {str(option.get("courseId") or "") for option in course_options}
+    first_course = (
+        configured_default_course
+        if configured_default_course in available_course_ids
+        else (course_options[0]["courseId"] if course_options else "")
+    )
     title = html.escape(str(page_config.get("title") or "Block Schedule"))
     subtitle = html.escape(str(page_config.get("subtitle") or ""))
     intro = html.escape(str(page_config.get("intro") or "Select a course, date, and start time."))

--- a/tests/test_block_start_time_selector.py
+++ b/tests/test_block_start_time_selector.py
@@ -153,6 +153,7 @@ class BlockStartTimeSelectorTests(unittest.TestCase):
         config = block_start_time_selector.load_block_schedule_page_configs()["arc"]
         self.assertEqual(["248288", "372258", "369209"], config["allowed_course_ids"])
         self.assertEqual(6, config["shared_cooldown_days_after_booking"])
+        self.assertEqual("372258", config["default_course_id"])
         self.assertIs(config["include_seated_classes"], True)
 
     def test_uses_live_availability_when_present(self):


### PR DESCRIPTION
Sets ARC Adult CPR/AED course 372258 as the default selected option while preserving explicit course deep-link overrides. Validated with Python compilation, the targeted ARC configuration test, generated HTML inspection, and local browser checks for both the default CPR/AED state and BLS deep-link override.