### PR TITLE
Add HSI credential to selector header

### DIFF
--- a/data/config/block_schedule_pages.json
+++ b/data/config/block_schedule_pages.json
@@ -533,6 +533,13 @@
       "intro": "Choose the HSI class that fits your requirement, then select a date and time.",
       "output_path": "docs/hsi.html",
       "legacy_schedule_path": "docs/hsi-schedule.html",
+      "header_credential": {
+        "image_url": "/images/HSI.png",
+        "image_alt": "HSI Approved Training Center",
+        "eyebrow": "Approved training",
+        "title": "HSI Approved Training Center",
+        "body": "HSI BLS, CPR, AED, and First Aid training at 910CPR."
+      },
       "compare_mode": {
         "enabled": true,
         "label": "Need HSI ASAP? Show all HSI options",

--- a/docs/hsi.html
+++ b/docs/hsi.html
@@ -606,6 +606,14 @@
         <p class="muted">Choose the HSI class that fits your requirement, then select a date and time.</p>
       </div>
       
+      <aside class="header-credential" aria-label="HSI Approved Training Center">
+        <img src="/images/HSI.png" alt="HSI Approved Training Center" loading="eager">
+        <div>
+          <span class="header-credential-eyebrow">Approved training</span>
+          <strong>HSI Approved Training Center</strong>
+          <p>HSI BLS, CPR, AED, and First Aid training at 910CPR.</p>
+        </div>
+      </aside>
     </div>
     
     <div class="family-help" aria-label="Course format guide">

--- a/tests/test_homepage_routing.py
+++ b/tests/test_homepage_routing.py
@@ -254,6 +254,13 @@ class HomepageRoutingTests(unittest.TestCase):
                 self.assertIn('src="/images/Logo_circle_AHA-Training-Site.webp"', heading)
                 self.assertIn("American Heart Association Training Site", heading)
 
+    def test_hsi_selector_shows_training_center_credential_at_top_right(self) -> None:
+        html = read(DOCS / "hsi.html")
+        heading = html[html.index('class="page-heading-row"'):html.index('class="family-help"')]
+        self.assertIn('class="header-credential"', heading)
+        self.assertIn('src="/images/HSI.png"', heading)
+        self.assertIn("HSI Approved Training Center", heading)
+
     def test_recent_student_payment_link_resolves_to_local_payment_page(self) -> None:
         html = read(DOCS / "next" / "index.html")
         self.assertIn('href="/pay/">Make Payment</a>', html)


### PR DESCRIPTION
## Summary
- show the HSI Approved Training Center credential in the top-right of the HSI selector heading
- preserve the credential through selector regeneration
- add regression coverage for the rendered position and logo

## Validation
- 24 focused homepage, routing, and shared-CSS tests pass
- JSON config validation passes