### PR TITLE
Restore compact homepage authority panel

### DIFF
--- a/docs/css/lander.css
+++ b/docs/css/lander.css
@@ -1156,7 +1156,10 @@ a {
 
 .home-authority {
   display: grid;
+  grid-template-rows: auto auto;
   gap: 9px;
+  min-height: 0;
+  align-self: start;
   margin: 8px 28px 0;
   padding: 12px 14px;
   border: 1px solid var(--border-strong);

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260719-home-authority">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/scripts/build_index_and_sitemap.py
+++ b/scripts/build_index_and_sitemap.py
@@ -1819,7 +1819,7 @@ def render_homepage() -> str:
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260719-home-authority">
 {render_gtm_head()}
 <script type="application/ld+json">
 {json.dumps({


### PR DESCRIPTION
## What changed
- prevents the homepage authority panel from inheriting a full-height affiliation layout
- keeps the three credential cards compact
- versions the homepage stylesheet URL so browsers fetch the repaired CSS immediately
- preserves the cache-busting URL in the homepage source generator

## Root cause
The homepage reused the standalone `affiliation-cluster` class, whose `min-height: 100%` stretched the authority block. Browsers could also retain the previous CSS because its URL had not changed.

## Validation
- `git diff --check` passed
- commit contains exactly three files and no schedule, class inventory, or Enrollware changes
