### PR TITLE
Ignore stale Maxim workflow facts

### DIFF
--- a/supabase/functions/maxim-portal/index.ts
+++ b/supabase/functions/maxim-portal/index.ts
@@ -156,13 +156,26 @@ async function listEmployees() {
         String(row.status_detail || ""),
       );
       const priorECardCode = row.prior_ecard_code || null;
-      const eCardCode = workflowStage >= 4
-        ? ecardCodeFromStatus(row.status_detail) || priorECardCode
+      const priorWorkflowClassDate = (workflowStage >= 3 || importedCompletion)
+        ? row.prior_class_date
+        : null;
+      const priorWorkflowClassAgeDays = priorWorkflowClassDate
+        ? calendarDayDifference(String(priorWorkflowClassDate), today)
+        : null;
+      const recentPriorWorkflowClassDate = (
+          priorWorkflowClassAgeDays !== null &&
+          priorWorkflowClassAgeDays >= 0 &&
+          priorWorkflowClassAgeDays <= 14
+        )
+        ? priorWorkflowClassDate
         : null;
       const currentClassDate = registration?.starts_at || row.scheduled_class_date ||
-        ((workflowStage >= 3 || importedCompletion) ? row.prior_class_date : null);
+        recentPriorWorkflowClassDate;
       const currentClassAgeDays = currentClassDate
         ? calendarDayDifference(String(currentClassDate), today)
+        : null;
+      const eCardCode = workflowStage >= 4 && currentClassDate
+        ? ecardCodeFromStatus(row.status_detail) || priorECardCode
         : null;
       const completedAt = (eCardCode || workflowStage === 3 || importedCompletion)
         ? currentClassDate || row.ecard_detected_at || row.updated_at
@@ -214,8 +227,8 @@ async function listEmployees() {
       registrationRequestedAt: registration?.created_at || null,
       registrationStatus: registration?.status || null,
       locationKey: registration?.location_key || null,
-      invoiceLabel: row.workflow_stage === 5 ? "INVOICED" : null,
-      invoiceDate: row.workflow_stage === 5 ? row.updated_at : null,
+      invoiceLabel: workflowStage === 5 && currentClassDate ? "INVOICED" : null,
+      invoiceDate: workflowStage === 5 && currentClassDate ? row.updated_at : null,
     };
   });
   const recentCompleted = mapped

--- a/tests/test_maxim_corporate_portal.py
+++ b/tests/test_maxim_corporate_portal.py
@@ -239,7 +239,7 @@ class MaximCorporatePortalTests(unittest.TestCase):
         self.assertIn("expirationDate >= currentMonth", source)
         self.assertIn("expirationDate < afterNextMonth", source)
         self.assertIn('history: mapped.filter((row: any) => row.bucket === "history")', source)
-        self.assertIn('invoiceLabel: row.workflow_stage === 5 ? "INVOICED"', source)
+        self.assertIn('invoiceLabel: workflowStage === 5 && currentClassDate ? "INVOICED"', source)
         self.assertIn("function ecardCodeFromStatus", source)
         self.assertIn("const priorECardCode = row.prior_ecard_code || null", source)
         self.assertIn("workflowStage >= 4", source)
@@ -263,8 +263,18 @@ class MaximCorporatePortalTests(unittest.TestCase):
         self.assertIn("classDate:employee.classDate||null", html)
         self.assertNotIn("classDate:employee.classDate||employee.priorClassDate", html)
         self.assertIn("priorECardCode:employee.priorECardCode||null", html)
-        self.assertIn("workflowStage >= 3 || importedCompletion", source)
+        self.assertIn("const priorWorkflowClassDate = (workflowStage >= 3 || importedCompletion)", source)
+        self.assertIn("priorWorkflowClassAgeDays >= 0", source)
+        self.assertIn("priorWorkflowClassAgeDays <= 14", source)
+        self.assertIn("const eCardCode = workflowStage >= 4 && currentClassDate", source)
         self.assertIn("Due ${safeText(displayDateOnly(person.expirationDate))}", html)
+
+    def test_old_stage_three_class_ecard_and_invoice_are_context_only(self) -> None:
+        source = MAXIM_EDGE_FUNCTION.read_text(encoding="utf-8")
+        self.assertIn("recentPriorWorkflowClassDate", source)
+        self.assertIn("registration?.starts_at || row.scheduled_class_date", source)
+        self.assertIn("invoiceLabel: workflowStage === 5 && currentClassDate", source)
+        self.assertIn("invoiceDate: workflowStage === 5 && currentClassDate", source)
 
     def test_current_class_location_reschedule_and_invoice_window_are_explicit(self) -> None:
         html = read_page()


### PR DESCRIPTION
Prevents old workflow-stage values and 2024 class/card/invoice facts from populating the current production Gantt. Only a scheduled class or a completed class within the 14-day activity window is treated as current. Tests: 35 passed.