### PR TITLE
Add direct employer requirement submission

### DIFF
--- a/docs/assets/booking-home.js
+++ b/docs/assets/booking-home.js
@@ -113,11 +113,18 @@
         <section class="home-exact-wording" aria-labelledby="chooser-exact-wording">
           <h4 id="chooser-exact-wording">My employer or school gave me exact wording</h4>
           <label for="course-requirement-text">Paste the exact requirement here.</label>
-          <textarea id="course-requirement-text" rows="3" data-course-requirement-text></textarea>
-          <div class="home-help-secondary-actions">
-            <button class="button secondary" type="button" data-copy-requirement-help>Copy help request</button>
-            <a class="button secondary" data-context-email-link href="mailto:info@910cpr.com?subject=Help%20Choosing%20the%20Right%20CPR%20Class&amp;body=I%20need%20help%20choosing%20the%20correct%20class.%0D%0A%0D%0ARequirement%20from%20my%20employer%2C%20school%2C%20or%20license%3A%0D%0A%5Binsert%20text%5D%0D%0A%0D%0AMy%20deadline%3A%0D%0A%5Binsert%20date%5D">Email with this context</a>
+          <textarea id="course-requirement-text" rows="3" maxlength="5000" data-course-requirement-text></textarea>
+          <div class="home-requirement-contact">
+            <label>Your name (optional)<input type="text" maxlength="120" autocomplete="name" data-requirement-name></label>
+            <label>Email<input type="email" maxlength="254" autocomplete="email" data-requirement-email></label>
+            <label>Phone<input type="tel" maxlength="40" autocomplete="tel" data-requirement-phone></label>
           </div>
+          <p class="home-requirement-note">Enter an email or phone so we can follow up.</p>
+          <div class="home-help-secondary-actions">
+            <button class="button primary" type="button" data-submit-requirement>Send this requirement to 910CPR</button>
+          </div>
+          <div class="home-requirement-status" role="status" aria-live="polite" data-requirement-status></div>
+          <input type="text" class="home-requirement-honeypot" tabindex="-1" autocomplete="off" aria-hidden="true" data-requirement-company>
         </section>
       </div>
     </section>
@@ -126,22 +133,142 @@
   const chooserToggle = sectionsRoot.querySelector("[data-course-chooser-toggle]");
   const chooser = sectionsRoot.querySelector("#guided-course-chooser");
   const requirementText = sectionsRoot.querySelector("[data-course-requirement-text]");
-  const copyHelpButton = sectionsRoot.querySelector("[data-copy-requirement-help]");
-  const contextEmailLink = sectionsRoot.querySelector("[data-context-email-link]");
+  const requirementName = sectionsRoot.querySelector("[data-requirement-name]");
+  const requirementEmail = sectionsRoot.querySelector("[data-requirement-email]");
+  const requirementPhone = sectionsRoot.querySelector("[data-requirement-phone]");
+  const requirementCompany = sectionsRoot.querySelector("[data-requirement-company]");
+  const requirementSubmit = sectionsRoot.querySelector("[data-submit-requirement]");
+  const requirementStatus = sectionsRoot.querySelector("[data-requirement-status]");
+  const requirementSessionKey = "910cprRequirementContext";
+  const requirementEndpoint =
+    "https://wktwgcnwdvbebcobgyey.supabase.co/functions/v1/requirement-inquiry";
+  const requirementOpenedAt = Date.now();
 
-  function updateContextEmail() {
-    if (!contextEmailLink) return;
-    const requirement = requirementText?.value.trim() || "[insert text]";
-    const body = [
-      "I need help choosing the correct class.",
-      "",
-      "Requirement from my employer, school, or license:",
-      requirement,
-      "",
-      "My deadline:",
-      "[insert date]",
-    ].join("\r\n");
-    contextEmailLink.href = `mailto:info@910cpr.com?subject=${encodeURIComponent("Help Choosing the Right CPR Class")}&body=${encodeURIComponent(body)}`;
+  function readSessionJson(key) {
+    try {
+      return JSON.parse(sessionStorage.getItem(key) || "null");
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function existingCustomerContext() {
+    const candidates = [
+      readSessionJson("910cprCustomer"),
+      readSessionJson("910cprInquiry"),
+      readSessionJson("910cprRegistration"),
+      readSessionJson("registrationDraft"),
+      readSessionJson("inquiryDraft"),
+    ].filter(Boolean);
+    return candidates.reduce((result, value) => ({ ...result, ...value }), {});
+  }
+
+  function selectedCourseContext() {
+    return (
+      readSessionJson("910cprSelectedCourse") || {
+        title: document.querySelector("h1")?.textContent?.trim() || "",
+        href: location.pathname + location.hash,
+      }
+    );
+  }
+
+  function saveRequirementSession(overrides) {
+    const current = readSessionJson(requirementSessionKey) || {};
+    const value = {
+      ...current,
+      requirement: requirementText?.value || "",
+      name: requirementName?.value || "",
+      email: requirementEmail?.value || "",
+      phone: requirementPhone?.value || "",
+      selectedCourse: selectedCourseContext(),
+      updatedAt: new Date().toISOString(),
+      ...overrides,
+    };
+    sessionStorage.setItem(requirementSessionKey, JSON.stringify(value));
+    return value;
+  }
+
+  function restoreRequirementSession() {
+    const saved = readSessionJson(requirementSessionKey);
+    const customer = existingCustomerContext();
+    if (requirementText) requirementText.value = saved?.requirement || "";
+    if (requirementName) requirementName.value = saved?.name || customer.name || customer.customerName || "";
+    if (requirementEmail) requirementEmail.value = saved?.email || customer.email || customer.customerEmail || "";
+    if (requirementPhone) requirementPhone.value = saved?.phone || customer.phone || customer.customerPhone || "";
+  }
+
+  async function submitRequirement() {
+    if (!requirementSubmit || !requirementStatus) return;
+    const requirement = requirementText?.value || "";
+    const email = requirementEmail?.value.trim() || "";
+    const phone = requirementPhone?.value.trim() || "";
+    if (requirement.trim().length < 10) {
+      requirementStatus.textContent = "Please enter the exact requirement before sending.";
+      requirementText?.focus();
+      return;
+    }
+    if (!email && !phone) {
+      requirementStatus.textContent = "Please enter an email or phone so 910CPR can follow up.";
+      (requirementEmail || requirementPhone)?.focus();
+      return;
+    }
+    if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      requirementStatus.textContent = "Please enter a valid email address.";
+      requirementEmail?.focus();
+      return;
+    }
+    if (!email && phone.replace(/\D/g, "").length < 7) {
+      requirementStatus.textContent = "Please enter a valid phone number.";
+      requirementPhone?.focus();
+      return;
+    }
+
+    const saved = saveRequirementSession();
+    const customer = existingCustomerContext();
+    const clientInquiryId =
+      saved.clientInquiryId ||
+      (crypto.randomUUID ? crypto.randomUUID() : `inq-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    saveRequirementSession({ clientInquiryId });
+    requirementSubmit.disabled = true;
+    requirementSubmit.textContent = "Sending…";
+    requirementStatus.textContent = "";
+
+    try {
+      const response = await fetch(requirementEndpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: requirementName?.value.trim() || customer.name || customer.customerName || "",
+          email,
+          phone,
+          requirement,
+          selectedCourse: selectedCourseContext(),
+          pageTitle: document.title,
+          pageUrl: location.href,
+          clientInquiryId,
+          inquiryId: customer.inquiryId || customer.inquiry_id || null,
+          registrationId: customer.registrationId || customer.registration_id || null,
+          companyWebsite: requirementCompany?.value || "",
+          formElapsedMs: Date.now() - requirementOpenedAt,
+        }),
+      });
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok || !result.sent || !result.inquiryId) {
+        throw new Error(result.error || "The message could not be delivered.");
+      }
+      saveRequirementSession({
+        serverInquiryId: result.inquiryId,
+        sentAt: result.sentAt || new Date().toISOString(),
+      });
+      requirementStatus.textContent =
+        "Sent to 910CPR. We’ll review the wording and help you determine the correct course.";
+    } catch (error) {
+      requirementStatus.textContent =
+        "We couldn’t send this yet. Your wording is still here—please check your connection and try again.";
+    } finally {
+      requirementSubmit.disabled = false;
+      requirementSubmit.textContent = "Send this requirement to 910CPR";
+    }
   }
 
   chooserToggle?.addEventListener("click", () => {
@@ -155,27 +282,24 @@
     }
   });
 
-  requirementText?.addEventListener("input", updateContextEmail);
-  updateContextEmail();
+  restoreRequirementSession();
+  [requirementText, requirementName, requirementEmail, requirementPhone].forEach((field) =>
+    field?.addEventListener("input", () => saveRequirementSession())
+  );
+  requirementSubmit?.addEventListener("click", submitRequirement);
+  window.get910CPRRequirementContext = () => readSessionJson(requirementSessionKey);
 
-  copyHelpButton?.addEventListener("click", async () => {
-    const requirement = requirementText?.value.trim() || "[insert text]";
-    const text = [
-      "I need help choosing the correct class.",
-      "",
-      "Requirement from my employer, school, or license:",
-      requirement,
-      "",
-      "My deadline:",
-      "[insert date]",
-    ].join("\n");
-    try {
-      await navigator.clipboard.writeText(text);
-      copyHelpButton.textContent = "Copied";
-    } catch (error) {
-      copyHelpButton.textContent = "Copy this text manually";
-      if (requirementText) requirementText.focus();
-    }
+  sectionsRoot.querySelectorAll(".home-choice-links a, .home-course-tile").forEach((link) => {
+    link.addEventListener("click", () => {
+      sessionStorage.setItem(
+        "910cprSelectedCourse",
+        JSON.stringify({
+          title: link.textContent.trim(),
+          href: link.getAttribute("href") || "",
+        })
+      );
+      saveRequirementSession();
+    });
   });
 
   function escapeHtml(value) {

--- a/docs/css/lander.css
+++ b/docs/css/lander.css
@@ -2073,10 +2073,65 @@ a {
   color: var(--text);
 }
 
+.home-requirement-contact {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.home-requirement-contact label {
+  display: grid;
+  gap: 5px;
+}
+
+.home-requirement-contact input {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font: inherit;
+  color: var(--text);
+}
+
+.home-requirement-note,
+.home-requirement-status {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.home-requirement-status:not(:empty) {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #eef6fb;
+  color: var(--heading);
+}
+
+.home-requirement-honeypot {
+  position: absolute !important;
+  left: -10000px !important;
+  width: 1px !important;
+  height: 1px !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+.home-help-secondary-actions .button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
 .home-help-secondary-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+@media (max-width: 720px) {
+  .home-requirement-contact {
+    grid-template-columns: 1fr;
+  }
 }
 
 .course-pathway-card {

--- a/supabase/functions/requirement-inquiry/README.md
+++ b/supabase/functions/requirement-inquiry/README.md
@@ -1,0 +1,17 @@
+# Requirement inquiry Edge Function
+
+Public server-side relay for the “My employer or school gave me exact wording”
+panel. The function validates and logs each inquiry, rate-limits by a salted IP
+hash, and reports success only after Resend confirms email acceptance.
+
+Required Supabase Edge Function secrets:
+
+- `RESEND_API_KEY`: Resend API key for a verified 910CPR sending domain.
+- `ADMIN_NOTIFY_EMAIL`: private administrative destination address.
+- `REQUIREMENT_FROM_EMAIL`: verified sender, such as `website@910cpr.com`.
+- `INQUIRY_HASH_SALT`: optional dedicated random salt for rate-limit hashes.
+
+The function is intentionally deployed without JWT verification because the
+website form is public. It compensates with an origin allowlist, honeypot,
+minimum form-completion time, strict size and field validation, hourly rate
+limiting, and a private RLS-enabled log table.

--- a/supabase/functions/requirement-inquiry/index.ts
+++ b/supabase/functions/requirement-inquiry/index.ts
@@ -1,0 +1,245 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+const ALLOWED_ORIGINS = new Set([
+  "https://www.910cpr.com",
+  "https://910cpr.com",
+  "http://localhost:8000",
+  "http://127.0.0.1:8000",
+]);
+const MAX_BODY_BYTES = 16_384;
+const MAX_PER_HOUR = 5;
+
+function corsHeaders(origin: string | null) {
+  const allowed = origin && ALLOWED_ORIGINS.has(origin) ? origin : "https://www.910cpr.com";
+  return {
+    "access-control-allow-origin": allowed,
+    "access-control-allow-headers": "content-type",
+    "access-control-allow-methods": "POST, OPTIONS",
+    "vary": "origin",
+  };
+}
+
+function json(body: unknown, status: number, origin: string | null) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders(origin), "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function clean(value: unknown, max: number) {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function validEmail(value: string) {
+  return !value || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function allowedPageUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && (url.hostname === "910cpr.com" || url.hostname === "www.910cpr.com");
+  } catch {
+    return false;
+  }
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+async function sha256(value: string) {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function supabaseRequest(path: string, init: RequestInit = {}) {
+  const url = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !serviceKey) throw new Error("database_configuration_missing");
+  return fetch(`${url}/rest/v1/${path}`, {
+    ...init,
+    headers: {
+      apikey: serviceKey,
+      authorization: `Bearer ${serviceKey}`,
+      "content-type": "application/json",
+      ...(init.headers || {}),
+    },
+  });
+}
+
+Deno.serve(async (request: Request) => {
+  const origin = request.headers.get("origin");
+  if (request.method === "OPTIONS") return new Response("ok", { headers: corsHeaders(origin) });
+  if (request.method !== "POST") return json({ error: "Method not allowed." }, 405, origin);
+  if (!origin || !ALLOWED_ORIGINS.has(origin)) return json({ error: "Origin not allowed." }, 403, origin);
+
+  const contentLength = Number(request.headers.get("content-length") || "0");
+  if (contentLength > MAX_BODY_BYTES) return json({ error: "Submission is too large." }, 413, origin);
+
+  let body: Record<string, unknown>;
+  try {
+    const raw = await request.text();
+    if (raw.length > MAX_BODY_BYTES) return json({ error: "Submission is too large." }, 413, origin);
+    body = JSON.parse(raw);
+  } catch {
+    return json({ error: "Invalid submission." }, 400, origin);
+  }
+
+  if (clean(body.companyWebsite, 200)) return json({ sent: true }, 200, origin);
+  const formElapsedMs = Number(body.formElapsedMs || 0);
+  if (!Number.isFinite(formElapsedMs) || formElapsedMs < 1500) {
+    return json({ error: "Please wait a moment and try again." }, 400, origin);
+  }
+
+  const name = clean(body.name, 120);
+  const email = clean(body.email, 254).toLowerCase();
+  const phone = clean(body.phone, 40);
+  const requirement = String(body.requirement ?? "").slice(0, 5000);
+  const pageTitle = clean(body.pageTitle, 240);
+  const pageUrl = clean(body.pageUrl, 1000);
+  const clientInquiryId = clean(body.clientInquiryId, 100);
+  const priorInquiryId = clean(body.inquiryId, 100);
+  const registrationId = clean(body.registrationId, 100);
+  const selectedCourse = body.selectedCourse && typeof body.selectedCourse === "object"
+    ? {
+      title: clean((body.selectedCourse as Record<string, unknown>).title, 200),
+      href: clean((body.selectedCourse as Record<string, unknown>).href, 500),
+    }
+    : { title: "", href: "" };
+
+  if (requirement.trim().length < 10) return json({ error: "Please enter the exact requirement." }, 400, origin);
+  if (!email && !phone) return json({ error: "Please enter an email or phone." }, 400, origin);
+  if (!validEmail(email)) return json({ error: "Please enter a valid email address." }, 400, origin);
+  if (!email && phone.replace(/\D/g, "").length < 7) {
+    return json({ error: "Please enter a valid phone number." }, 400, origin);
+  }
+  if (!allowedPageUrl(pageUrl)) return json({ error: "Invalid page URL." }, 400, origin);
+
+  const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "";
+  const salt = Deno.env.get("INQUIRY_HASH_SALT") || Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+  const ipHash = await sha256(`${salt}:${forwardedFor}`);
+  const since = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const rateResponse = await supabaseRequest(
+    `requirement_inquiries?select=id&ip_hash=eq.${encodeURIComponent(ipHash)}&created_at=gte.${encodeURIComponent(since)}&limit=${MAX_PER_HOUR}`
+  );
+  if (!rateResponse.ok) {
+    console.error("requirement_inquiry_rate_lookup_failed", rateResponse.status);
+    return json({ error: "The service is temporarily unavailable. Please try again." }, 503, origin);
+  }
+  const recent = await rateResponse.json();
+  if (Array.isArray(recent) && recent.length >= MAX_PER_HOUR) {
+    console.warn("requirement_inquiry_rate_limited", ipHash.slice(0, 12));
+    return json({ error: "Too many requests. Please wait and try again." }, 429, origin);
+  }
+
+  const submittedAt = new Date().toISOString();
+  const insertResponse = await supabaseRequest("requirement_inquiries", {
+    method: "POST",
+    headers: { prefer: "return=representation" },
+    body: JSON.stringify({
+      name: name || null,
+      email: email || null,
+      phone: phone || null,
+      requirement_text: requirement,
+      selected_course: selectedCourse,
+      page_title: pageTitle,
+      page_url: pageUrl,
+      submitted_at: submittedAt,
+      client_inquiry_id: clientInquiryId || null,
+      prior_inquiry_id: priorInquiryId || null,
+      registration_id: registrationId || null,
+      ip_hash: ipHash,
+      user_agent: clean(request.headers.get("user-agent"), 500),
+      delivery_status: "pending",
+    }),
+  });
+  if (!insertResponse.ok) {
+    console.error("requirement_inquiry_insert_failed", insertResponse.status);
+    return json({ error: "The service is temporarily unavailable. Please try again." }, 503, origin);
+  }
+  const inserted = await insertResponse.json();
+  const inquiryId = String(inserted?.[0]?.id || "");
+
+  const resendKey = Deno.env.get("RESEND_API_KEY");
+  const adminEmail = Deno.env.get("ADMIN_NOTIFY_EMAIL");
+  const fromEmail = Deno.env.get("REQUIREMENT_FROM_EMAIL");
+  if (!resendKey || !adminEmail || !fromEmail) {
+    console.error("requirement_inquiry_email_configuration_missing", inquiryId);
+    await supabaseRequest(`requirement_inquiries?id=eq.${encodeURIComponent(inquiryId)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ delivery_status: "configuration_error" }),
+    });
+    return json({ error: "Email delivery is not configured. Please try again later." }, 503, origin);
+  }
+
+  const courseLabel = selectedCourse.title || "Not selected";
+  const text = [
+    "A customer submitted exact employer or school wording.",
+    "",
+    `Name: ${name || "Not provided"}`,
+    `Email: ${email || "Not provided"}`,
+    `Phone: ${phone || "Not provided"}`,
+    `Course: ${courseLabel}`,
+    `Course link: ${selectedCourse.href || "Not provided"}`,
+    `Page: ${pageTitle}`,
+    `URL: ${pageUrl}`,
+    `Submitted: ${submittedAt}`,
+    `Inquiry ID: ${inquiryId}`,
+    `Prior inquiry ID: ${priorInquiryId || "None"}`,
+    `Registration ID: ${registrationId || "None"}`,
+    "",
+    "Exact requirement:",
+    requirement,
+  ].join("\n");
+  const html = `<h2>Employer or school requirement</h2>
+    <p><strong>Name:</strong> ${escapeHtml(name || "Not provided")}<br>
+    <strong>Email:</strong> ${escapeHtml(email || "Not provided")}<br>
+    <strong>Phone:</strong> ${escapeHtml(phone || "Not provided")}<br>
+    <strong>Course:</strong> ${escapeHtml(courseLabel)}<br>
+    <strong>Page:</strong> ${escapeHtml(pageTitle)}<br>
+    <strong>URL:</strong> ${escapeHtml(pageUrl)}<br>
+    <strong>Submitted:</strong> ${escapeHtml(submittedAt)}<br>
+    <strong>Inquiry ID:</strong> ${escapeHtml(inquiryId)}<br>
+    <strong>Prior inquiry ID:</strong> ${escapeHtml(priorInquiryId || "None")}<br>
+    <strong>Registration ID:</strong> ${escapeHtml(registrationId || "None")}</p>
+    <h3>Exact requirement</h3><pre style="white-space:pre-wrap">${escapeHtml(requirement)}</pre>`;
+
+  const emailResponse = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { authorization: `Bearer ${resendKey}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      from: fromEmail,
+      to: [adminEmail],
+      reply_to: email || undefined,
+      subject: `Course requirement help${name ? ` — ${name}` : ""}`,
+      text,
+      html,
+    }),
+  });
+  const emailResult = await emailResponse.json().catch(() => ({}));
+  if (!emailResponse.ok || !emailResult.id) {
+    console.error("requirement_inquiry_email_failed", inquiryId, emailResponse.status);
+    await supabaseRequest(`requirement_inquiries?id=eq.${encodeURIComponent(inquiryId)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ delivery_status: "failed" }),
+    });
+    return json({ error: "Email delivery failed. Please try again." }, 502, origin);
+  }
+
+  await supabaseRequest(`requirement_inquiries?id=eq.${encodeURIComponent(inquiryId)}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      delivery_status: "sent",
+      delivered_at: new Date().toISOString(),
+      provider_message_id: String(emailResult.id).slice(0, 200),
+    }),
+  });
+  console.log("requirement_inquiry_sent", inquiryId);
+  return json({ sent: true, inquiryId, sentAt: submittedAt }, 200, origin);
+});

--- a/supabase/migrations/20260730123000_requirement_inquiries.sql
+++ b/supabase/migrations/20260730123000_requirement_inquiries.sql
@@ -1,0 +1,35 @@
+create table if not exists public.requirement_inquiries (
+  id uuid primary key default gen_random_uuid(),
+  name text,
+  email text,
+  phone text,
+  requirement_text text not null,
+  selected_course jsonb not null default '{}'::jsonb,
+  page_title text not null,
+  page_url text not null,
+  submitted_at timestamptz not null,
+  client_inquiry_id text,
+  prior_inquiry_id text,
+  registration_id text,
+  ip_hash text not null,
+  user_agent text,
+  delivery_status text not null default 'pending'
+    check (delivery_status in ('pending', 'sent', 'failed', 'configuration_error')),
+  delivered_at timestamptz,
+  provider_message_id text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.requirement_inquiries enable row level security;
+
+revoke all on table public.requirement_inquiries from anon, authenticated;
+
+create index if not exists requirement_inquiries_ip_created_idx
+  on public.requirement_inquiries (ip_hash, created_at desc);
+
+create index if not exists requirement_inquiries_registration_idx
+  on public.requirement_inquiries (registration_id)
+  where registration_id is not null;
+
+comment on table public.requirement_inquiries is
+  'Private employer/school requirement submissions. Access is limited to server-side service-role operations.';

--- a/tests/test_requirement_inquiry.py
+++ b/tests/test_requirement_inquiry.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOKING_HOME = ROOT / "docs" / "assets" / "booking-home.js"
+FUNCTION = ROOT / "supabase" / "functions" / "requirement-inquiry" / "index.ts"
+MIGRATION = ROOT / "supabase" / "migrations" / "20260730123000_requirement_inquiries.sql"
+
+
+class RequirementInquiryTests(unittest.TestCase):
+    def test_shared_component_uses_server_submission(self) -> None:
+        source = BOOKING_HOME.read_text(encoding="utf-8")
+        self.assertIn("Send this requirement to 910CPR", source)
+        self.assertIn("/functions/v1/requirement-inquiry", source)
+        self.assertNotIn("data-copy-requirement-help", source)
+        self.assertNotIn("data-context-email-link", source)
+        self.assertNotIn("mailto:info@910cpr.com", source)
+        self.assertIn("sessionStorage.setItem(requirementSessionKey", source)
+        self.assertIn("if (!response.ok || !result.sent || !result.inquiryId)", source)
+
+    def test_endpoint_keeps_destination_server_side(self) -> None:
+        source = FUNCTION.read_text(encoding="utf-8")
+        self.assertIn('Deno.env.get("ADMIN_NOTIFY_EMAIL")', source)
+        self.assertIn('Deno.env.get("RESEND_API_KEY")', source)
+        self.assertIn("requirement_inquiry_rate_limited", source)
+        self.assertIn("requirement_inquiry_sent", source)
+        self.assertIn("MAX_PER_HOUR = 5", source)
+        self.assertIn('phone.replace(/\\D/g, "").length < 7', source)
+        self.assertNotIn("office@910cpr.com", source)
+        self.assertNotIn("info@910cpr.com", source)
+
+    def test_inquiry_table_is_private(self) -> None:
+        source = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("enable row level security", source)
+        self.assertIn("revoke all", source)
+        self.assertIn("registration_id", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Replaced the shared Copy/Copied and client-side mailto controls with one primary “Send this requirement to 910CPR” button.
- Added optional customer contact fields, client-side validation, disabled/sending state, confirmed-success copy, retry behavior, and session persistence.
- Added a public Supabase Edge Function that validates requests, uses an origin allowlist and honeypot, rate-limits by salted IP hash, logs submissions privately, and reports success only after Resend confirms acceptance.
- Added a private RLS-enabled `requirement_inquiries` table with registration/inquiry linkage fields.
- Added focused regression tests and deployment-secret documentation.

## Why

The prior controls only copied text locally or opened a mail client. They could not reliably relay the employer/school wording to 910CPR or prove that a message was sent.

## Validation

- `node --check docs/assets/booking-home.js`
- `python -B -m unittest tests/test_requirement_inquiry.py` — 3 passing
- `git diff --check`
- Production Supabase migration applied and Edge Function deployed.
- Endpoint test confirmed durable logging and correctly returned HTTP 503 rather than claiming success because email-delivery secrets are not yet configured.

## Deployment blocker

Do not merge/publish the frontend until these Supabase Edge Function secrets are configured and a real delivery test passes:

- `RESEND_API_KEY`
- `ADMIN_NOTIFY_EMAIL`
- `REQUIREMENT_FROM_EMAIL`
- optional `INQUIRY_HASH_SALT`

The public GitHub Pages frontend has intentionally not been changed in production yet.