### PR TITLE
Automate LinkedIn event publishing

### DIFF
--- a/.github/workflows/linkedin-event-sync.yml
+++ b/.github/workflows/linkedin-event-sync.yml
@@ -1,0 +1,97 @@
+name: LinkedIn Event Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Create/update LinkedIn Events"
+        required: true
+        default: false
+        type: boolean
+      max_events:
+        description: "Maximum Events changed in this run"
+        required: true
+        default: "1"
+        type: string
+      session_id:
+        description: "Optional single Enrollware session ID"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: linkedin-event-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate interface
+        run: |
+          python -m py_compile scripts/linkedin_event_sync.py scripts/linkedin_refresh_token.py
+          python scripts/linkedin_event_sync.py --output /tmp/linkedin-event-plan.json
+          python - <<'PY'
+          import json
+          report = json.load(open('/tmp/linkedin-event-plan.json'))
+          print(f"Eligible: {report['eligible_count']}; skipped: {len(report['skipped'])}")
+          PY
+
+      - name: Refresh LinkedIn access token
+        if: ${{ inputs.apply }}
+        id: token
+        env:
+          LINKEDIN_CLIENT_ID: ${{ secrets.LINKEDIN_CLIENT_ID }}
+          LINKEDIN_CLIENT_SECRET: ${{ secrets.LINKEDIN_CLIENT_SECRET }}
+          LINKEDIN_REFRESH_TOKEN: ${{ secrets.LINKEDIN_REFRESH_TOKEN }}
+        run: |
+          token="$(python scripts/linkedin_refresh_token.py)"
+          echo "::add-mask::$token"
+          echo "access_token=$token" >> "$GITHUB_OUTPUT"
+
+      - name: Synchronize Events
+        id: sync
+        env:
+          LINKEDIN_ACCESS_TOKEN: ${{ steps.token.outputs.access_token || secrets.LINKEDIN_ACCESS_TOKEN }}
+          LINKEDIN_ORGANIZATION_URN: ${{ secrets.LINKEDIN_ORGANIZATION_URN }}
+          LINKEDIN_EVENT_BACKGROUND_IMAGE_URN: ${{ secrets.LINKEDIN_EVENT_BACKGROUND_IMAGE_URN }}
+        run: |
+          args=(--max-events "${{ inputs.max_events }}" --output /tmp/linkedin-event-report.json)
+          if [[ -n "${{ inputs.session_id }}" ]]; then
+            args+=(--session-id "${{ inputs.session_id }}")
+          fi
+          if [[ "${{ inputs.apply }}" == "true" ]]; then
+            args+=(--apply)
+          fi
+          python scripts/linkedin_event_sync.py "${args[@]}"
+
+      - name: Save LinkedIn state
+        if: ${{ inputs.apply && always() }}
+        run: |
+          if git diff --quiet -- data/runtime/linkedin_event_state.json; then
+            echo "No state change."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- data/runtime/linkedin_event_state.json
+          git commit -m "chore: update LinkedIn event sync state"
+          git push
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linkedin-event-sync-report
+          path: |
+            /tmp/linkedin-event-plan.json
+            /tmp/linkedin-event-report.json
+          if-no-files-found: ignore

--- a/data/linkedin_event_sync.json
+++ b/data/linkedin_event_sync.json
@@ -1,0 +1,17 @@
+{
+  "organizer_urn": "",
+  "background_image_urn": "",
+  "public_location_prefixes": [
+    "::"
+  ],
+  "promoted_session_ids": [],
+  "location_addresses": {
+    ":: Wilmington; Shipyard Blvd": {
+      "line1": "4018 Shipyard Blvd",
+      "city": "Wilmington",
+      "geographicArea": "North Carolina",
+      "postalCode": "28403",
+      "country": "US"
+    }
+  }
+}

--- a/docs/LINKEDIN_EVENT_SYNC.md
+++ b/docs/LINKEDIN_EVENT_SYNC.md
@@ -1,0 +1,62 @@
+# LinkedIn Event Sync
+
+This interface publishes real, seated public classes from
+`docs/data/schedule_future.json` as LinkedIn Page Events. Dynamic appointment
+possibilities are intentionally excluded.
+
+## Safety model
+
+- Dry-run is the default.
+- Only future, active, open, directly bookable sessions at configured public
+  location prefixes are eligible.
+- A configured address must match before an Event can be planned.
+- `promoted_session_ids` can include a deliberately promoted future session,
+  but it does not bypass the public-address requirement.
+- State is written after every successful API change to prevent duplicates.
+
+## Dry-run
+
+```powershell
+python scripts/linkedin_event_sync.py --output debug/linkedin_event_plan.json
+```
+
+Review `eligible_count`, every event payload, and the skipped reasons before a
+live run.
+
+## Required LinkedIn configuration
+
+After LinkedIn approves the developer application:
+
+1. Add the 910CPR organization URN to `data/linkedin_event_sync.json` or set
+   `LINKEDIN_ORGANIZATION_URN`.
+2. Upload/approve the course cover asset and add its asset URN to the config or
+   set `LINKEDIN_EVENT_BACKGROUND_IMAGE_URN`.
+3. Store the OAuth token outside the repository as `LINKEDIN_ACCESS_TOKEN`.
+4. The token must include `rw_events` and the organization posting permission
+   granted with the approved Event Management/Community Management products.
+
+## Live synchronization
+
+```powershell
+$env:LINKEDIN_ACCESS_TOKEN = "..."
+python scripts/linkedin_event_sync.py --apply
+```
+
+Never commit access tokens. Live execution is intentionally unavailable until
+LinkedIn approves the app and the required organization scopes are granted.
+
+## GitHub Actions
+
+The `LinkedIn Event Sync` workflow is manual-only during rollout. Its defaults
+are safe: dry-run with at most one changed Event when apply is enabled. Review
+the uploaded audit report and the resulting LinkedIn Event before increasing
+the batch size.
+
+Repository secrets:
+
+- `LINKEDIN_ACCESS_TOKEN` (fallback; current access token)
+- `LINKEDIN_REFRESH_TOKEN`
+- `LINKEDIN_CLIENT_ID`
+- `LINKEDIN_CLIENT_SECRET`
+- `LINKEDIN_ORGANIZATION_URN`
+- `LINKEDIN_EVENT_BACKGROUND_IMAGE_URN` (optional)

--- a/scripts/linkedin_event_sync.py
+++ b/scripts/linkedin_event_sync.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Plan and publish seated 910CPR sessions as LinkedIn Page Events.
+
+Dry-run is the default.  Live writes require --apply plus LinkedIn credentials.
+The authoritative input remains docs/data/schedule_future.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEDULE = ROOT / "docs/data/schedule_future.json"
+DEFAULT_CONFIG = ROOT / "data/linkedin_event_sync.json"
+DEFAULT_STATE = ROOT / "data/runtime/linkedin_event_state.json"
+
+
+def load_json(path: Path, default: Any = None) -> Any:
+    if not path.exists():
+        if default is not None:
+            return default
+        raise FileNotFoundError(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def epoch_ms(value: str) -> int:
+    return int(datetime.fromisoformat(value).timestamp() * 1000)
+
+
+def future(value: str) -> bool:
+    return datetime.fromisoformat(value) > datetime.now(timezone.utc)
+
+
+def normalized_location(value: str | None) -> str:
+    return (value or "").strip()
+
+
+@dataclass(frozen=True)
+class PlannedEvent:
+    session_id: str
+    payload: dict[str, Any]
+    post_payload: dict[str, Any]
+    fingerprint: str
+
+
+def event_description(session: dict[str, Any]) -> str:
+    parts = [
+        session.get("mapped_short_description") or session.get("course_name"),
+        "View details and register through 910CPR.",
+    ]
+    return "\n\n".join(part.strip() for part in parts if part and part.strip())
+
+
+def address_for(location: str, config: dict[str, Any]) -> dict[str, str] | None:
+    for prefix, address in config.get("location_addresses", {}).items():
+        if location.startswith(prefix):
+            return address
+    return None
+
+
+def eligible(session: dict[str, Any], config: dict[str, Any]) -> tuple[bool, str]:
+    session_id = str(session.get("session_id") or "")
+    promoted = session_id in {str(v) for v in config.get("promoted_session_ids", [])}
+    if session.get("build_classification") != "future" or not future(session["start_at"]):
+        return False, "not future"
+    if session.get("session_status") != "active":
+        return False, "inactive"
+    if session.get("registration_status") not in {"open", None}:
+        return False, "registration closed"
+    if not session.get("public_direct_booking") and not promoted:
+        return False, "not public"
+    if session.get("is_full") and not promoted:
+        return False, "full"
+    location = normalized_location(session.get("location_display") or session.get("location_name"))
+    prefixes = config.get("public_location_prefixes", ["::"])
+    if not any(location.startswith(prefix) for prefix in prefixes) and not promoted:
+        return False, "private location"
+    if not address_for(location, config):
+        return False, "unmapped public address"
+    return True, "promoted override" if promoted else "public seated class"
+
+
+def build_event(session: dict[str, Any], config: dict[str, Any]) -> PlannedEvent:
+    location = normalized_location(session.get("location_display") or session.get("location_name"))
+    session_id = str(session["session_id"])
+    organizer = config.get("organizer_urn") or os.getenv("LINKEDIN_ORGANIZATION_URN")
+    image_urn = config.get("background_image_urn") or os.getenv("LINKEDIN_EVENT_BACKGROUND_IMAGE_URN")
+    if not organizer:
+        organizer = "urn:li:organization:REQUIRED"
+    payload: dict[str, Any] = {
+        "name": {"localized": {"en_US": session.get("mapped_clean_title") or session["course_name"]}},
+        "description": {"localized": {"en_US": {"rawText": event_description(session)}}},
+        "organizer": organizer,
+        "startsAt": epoch_ms(session["start_at"]),
+        "discoveryMode": "LISTED",
+        "type": {
+            "inPerson": {
+                "endsAt": epoch_ms(session["end_at"]),
+                "url": session["registration_url"],
+                "address": address_for(location, config),
+                "venueDetails": {"localized": {"en_US": {"rawText": location.removeprefix("::").strip()}}},
+            }
+        },
+    }
+    if image_urn:
+        payload["backgroundImage"] = image_urn
+    post_payload = {
+        "author": organizer,
+        "commentary": "",
+        "visibility": "PUBLIC",
+        "distribution": {
+            "feedDistribution": "MAIN_FEED",
+            "targetEntities": [],
+            "thirdPartyDistributionChannels": [],
+        },
+        "content": {"reference": {"id": "urn:li:event:{event_id}"}},
+        "lifecycleState": "PUBLISHED",
+        "isReshareDisabledByAuthor": False,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    fingerprint = hashlib.sha256(canonical.encode()).hexdigest()
+    return PlannedEvent(session_id, payload, post_payload, fingerprint)
+
+
+class LinkedInClient:
+    def __init__(self, token: str, version: str) -> None:
+        self.token = token
+        self.version = version
+
+    def request(self, method: str, path: str, payload: dict[str, Any], restli_method: str | None = None) -> tuple[int, dict[str, str], Any]:
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Restli-Protocol-Version": "2.0.0",
+            "Linkedin-Version": self.version,
+        }
+        if restli_method:
+            headers["X-RestLi-Method"] = restli_method
+        request = urllib.request.Request(
+            f"https://api.linkedin.com/rest/{path}",
+            data=json.dumps(payload).encode(),
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                raw = response.read()
+                body = json.loads(raw) if raw else None
+                return response.status, dict(response.headers.items()), body
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"LinkedIn API {exc.code} for {path}: {detail}") from exc
+
+    def create_event(self, payload: dict[str, Any]) -> str:
+        _, headers, body = self.request("POST", "events", payload, "create")
+        event_id = (body or {}).get("id") or headers.get("x-restli-id") or headers.get("X-RestLi-Id")
+        if not event_id:
+            raise RuntimeError("LinkedIn did not return an event ID")
+        return str(event_id)
+
+    def publish_event(self, event_id: str, payload: dict[str, Any]) -> str | None:
+        body = json.loads(json.dumps(payload).replace("{event_id}", event_id))
+        _, headers, _ = self.request("POST", "posts", body)
+        return headers.get("x-restli-id") or headers.get("X-RestLi-Id")
+
+    def update_event(self, event_id: str, payload: dict[str, Any]) -> None:
+        mutable = {k: v for k, v in payload.items() if k not in {"organizer"}}
+        self.request("POST", f"events/{event_id}", {"patch": {"$set": mutable}}, "partial_update")
+
+
+def plan(schedule_path: Path, config_path: Path) -> tuple[list[PlannedEvent], list[dict[str, str]]]:
+    schedule = load_json(schedule_path)
+    config = load_json(config_path)
+    events: list[PlannedEvent] = []
+    skipped: list[dict[str, str]] = []
+    for session in schedule.get("sessions", []):
+        ok, reason = eligible(session, config)
+        if ok:
+            events.append(build_event(session, config))
+        else:
+            skipped.append({"session_id": str(session.get("session_id") or ""), "reason": reason})
+    return events, skipped
+
+
+def save_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--schedule", type=Path, default=DEFAULT_SCHEDULE)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--state", type=Path, default=DEFAULT_STATE)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--session-id", help="Limit the run to one Enrollware session ID")
+    parser.add_argument("--max-events", type=int, default=0, help="Maximum changed events to write; 0 means unlimited")
+    args = parser.parse_args()
+
+    events, skipped = plan(args.schedule, args.config)
+    if args.session_id:
+        events = [event for event in events if event.session_id == args.session_id]
+    report: dict[str, Any] = {
+        "mode": "apply" if args.apply else "dry-run",
+        "eligible_count": len(events),
+        "events": [{"session_id": e.session_id, "fingerprint": e.fingerprint, "payload": e.payload} for e in events],
+        "skipped": skipped,
+    }
+    if not args.apply:
+        rendered = json.dumps(report, indent=2)
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered + "\n", encoding="utf-8")
+        print(rendered)
+        return 0
+
+    token = os.getenv("LINKEDIN_ACCESS_TOKEN")
+    if not token:
+        raise SystemExit("LINKEDIN_ACCESS_TOKEN is required with --apply")
+    state = load_json(args.state, default={"sessions": {}})
+    client = LinkedInClient(token, os.getenv("LINKEDIN_API_VERSION", "202607"))
+    actions: list[dict[str, str]] = []
+    changed = 0
+    for event in events:
+        existing = state["sessions"].get(event.session_id)
+        if existing and existing.get("fingerprint") == event.fingerprint:
+            actions.append({"session_id": event.session_id, "action": "unchanged"})
+            continue
+        if existing:
+            if args.max_events and changed >= args.max_events:
+                actions.append({"session_id": event.session_id, "action": "deferred"})
+                continue
+            client.update_event(existing["event_id"], event.payload)
+            existing["fingerprint"] = event.fingerprint
+            actions.append({"session_id": event.session_id, "action": "updated"})
+            changed += 1
+        else:
+            if args.max_events and changed >= args.max_events:
+                actions.append({"session_id": event.session_id, "action": "deferred"})
+                continue
+            event_id = client.create_event(event.payload)
+            post_id = client.publish_event(event_id, event.post_payload)
+            state["sessions"][event.session_id] = {
+                "event_id": event_id,
+                "post_id": post_id,
+                "fingerprint": event.fingerprint,
+            }
+            actions.append({"session_id": event.session_id, "action": "created"})
+            changed += 1
+        save_state(args.state, state)
+    report["actions"] = actions
+    rendered = json.dumps(report, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/linkedin_refresh_token.py
+++ b/scripts/linkedin_refresh_token.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Exchange LinkedIn's long-lived refresh token for a current access token."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+
+def main() -> int:
+    required = {
+        "client_id": os.getenv("LINKEDIN_CLIENT_ID"),
+        "client_secret": os.getenv("LINKEDIN_CLIENT_SECRET"),
+        "refresh_token": os.getenv("LINKEDIN_REFRESH_TOKEN"),
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        raise SystemExit("Missing LinkedIn credential(s): " + ", ".join(missing))
+    form = urllib.parse.urlencode({"grant_type": "refresh_token", **required}).encode()
+    request = urllib.request.Request(
+        "https://www.linkedin.com/oauth/v2/accessToken",
+        data=form,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    access_token = payload.get("access_token")
+    if not access_token:
+        raise SystemExit("LinkedIn refresh response did not contain an access token")
+    # The caller captures stdout. Never print the response or refresh token.
+    print(access_token)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_linkedin_event_sync.py
+++ b/tests/test_linkedin_event_sync.py
@@ -1,0 +1,76 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts/linkedin_event_sync.py"
+SPEC = importlib.util.spec_from_file_location("linkedin_event_sync", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+CONFIG = {
+    "organizer_urn": "urn:li:organization:123",
+    "background_image_urn": "urn:li:digitalmediaAsset:456",
+    "public_location_prefixes": ["::"],
+    "promoted_session_ids": [],
+    "location_addresses": {
+        ":: Wilmington; Shipyard Blvd": {
+            "line1": "4018 Shipyard Blvd",
+            "city": "Wilmington",
+            "geographicArea": "North Carolina",
+            "postalCode": "28403",
+            "country": "US",
+        }
+    },
+}
+
+
+def session(**overrides):
+    base = {
+        "session_id": "99",
+        "course_name": "AHA BLS Provider",
+        "mapped_clean_title": "AHA BLS Provider",
+        "mapped_short_description": "Hands-on BLS training.",
+        "start_at": "2099-08-10T09:00:00-04:00",
+        "end_at": "2099-08-10T12:00:00-04:00",
+        "build_classification": "future",
+        "session_status": "active",
+        "registration_status": "open",
+        "public_direct_booking": True,
+        "is_full": False,
+        "location_display": ":: Wilmington; Shipyard Blvd - B",
+        "registration_url": "https://example.test/enroll?id=99",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_public_seated_session_is_eligible():
+    assert MODULE.eligible(session(), CONFIG) == (True, "public seated class")
+
+
+def test_private_location_is_not_eligible():
+    ok, reason = MODULE.eligible(session(location_display="Private Client"), CONFIG)
+    assert not ok
+    assert reason == "private location"
+
+
+def test_payload_uses_session_times_registration_and_address():
+    event = MODULE.build_event(session(), CONFIG)
+    assert event.payload["organizer"] == "urn:li:organization:123"
+    assert event.payload["type"]["inPerson"]["url"].endswith("id=99")
+    assert event.payload["type"]["inPerson"]["address"]["line1"] == "4018 Shipyard Blvd"
+    assert event.payload["backgroundImage"] == "urn:li:digitalmediaAsset:456"
+
+
+def test_promoted_session_can_override_nonpublic_flag_but_not_location_mapping():
+    config = {**CONFIG, "promoted_session_ids": ["99"]}
+    assert MODULE.eligible(session(public_direct_booking=False), config)[0]
+    ok, reason = MODULE.eligible(
+        session(public_direct_booking=False, location_display="Private Client"), config
+    )
+    assert not ok
+    assert reason == "unmapped public address"


### PR DESCRIPTION
## Summary
- add a LinkedIn Events API sync for eligible public seated Enrollware classes
- refresh OAuth access tokens from the stored long-lived refresh token
- add a manually triggered GitHub Actions workflow with dry-run support and a one-event default limit
- persist LinkedIn event IDs so later runs update rather than duplicate events

## Validation
- Python compilation passed
- event eligibility and payload tests passed
- current schedule dry run found 37 eligible classes and excluded 2 closed registrations

## Rollout
The first live workflow run remains capped at one LinkedIn Event for verification before increasing the batch size.