### PR TITLE
Fix LinkedIn event images and synchronization state

### DIFF
--- a/.github/workflows/linkedin-event-sync.yml
+++ b/.github/workflows/linkedin-event-sync.yml
@@ -76,14 +76,19 @@ jobs:
       - name: Save LinkedIn state
         if: ${{ inputs.apply && always() }}
         run: |
-          if git diff --quiet -- data/runtime/linkedin_event_state.json; then
+          if [[ ! -f data/runtime/linkedin_event_state.json ]]; then
             echo "No state change."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- data/runtime/linkedin_event_state.json
+          if git diff --cached --quiet; then
+            echo "No state change."
+            exit 0
+          fi
           git commit -m "chore: update LinkedIn event sync state"
+          git pull --rebase origin main
           git push
 
       - name: Upload audit report

--- a/data/course_descriptions.json
+++ b/data/course_descriptions.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "910cpr-course-descriptions.v1",
+  "courses": {
+    "aha_bls_provider": {
+      "audience": "Designed for healthcare professionals and clinical teams who need an American Heart Association BLS Provider certification.",
+      "overview": "This instructor-led course includes hands-on practice in high-quality adult, child and infant CPR, AED use, ventilations, choking response and team-based resuscitation. Skills are practiced and evaluated using realistic healthcare scenarios.",
+      "credential": "Successful participants receive an American Heart Association BLS Provider course completion card, valid for two years."
+    },
+    "aha_bls_provider_renewal": {
+      "audience": "Designed for current or recently expired BLS providers who need to renew their American Heart Association certification.",
+      "overview": "This renewal course reviews and evaluates high-quality adult, child and infant CPR, AED use, ventilations, choking response and effective team-based resuscitation.",
+      "credential": "Successful participants receive an American Heart Association BLS Provider course completion card, valid for two years."
+    },
+    "aha_heartcode_bls": {
+      "audience": "Designed for healthcare professionals completing the hands-on portion of the American Heart Association HeartCode BLS blended course.",
+      "overview": "During this skills session, participants demonstrate high-quality adult, child and infant CPR, AED use, ventilations and choking response with an AHA instructor.",
+      "preparation": "Complete the AHA HeartCode BLS online course before your appointment and bring the online completion certificate to the skills session.",
+      "credential": "After successful skills testing, participants receive an American Heart Association BLS Provider course completion card, valid for two years."
+    },
+    "aha_heartsaver_first_aid_cpr_aed": {
+      "audience": "Designed for people with little or no medical training who need CPR, AED and first aid certification for employment, regulatory requirements or personal preparedness.",
+      "overview": "This instructor-led class includes hands-on adult CPR, AED use, choking response and practical first aid. Topics include medical, injury and environmental emergencies, severe bleeding, stroke recognition, opioid emergencies and naloxone, heat illness, burns, allergic reactions, seizures and asthma.",
+      "credential": "Successful participants receive an American Heart Association Heartsaver First Aid CPR AED course completion card, valid for two years."
+    },
+    "aha_acls_provider_initial": {
+      "audience": "Designed for healthcare professionals who direct or participate in the management of cardiopulmonary arrest and other cardiovascular emergencies.",
+      "overview": "This initial ACLS course uses instruction, skills stations and team scenarios to cover systematic assessment, cardiac arrest algorithms, rhythm and medication concepts, airway and ventilation decisions, stroke recognition, post-cardiac-arrest care and high-performance team communication.",
+      "credential": "Successful participants receive an American Heart Association ACLS Provider course completion card, valid for two years."
+    },
+    "aha_acls_provider_renewal": {
+      "audience": "Designed for current or recently expired ACLS providers who need to renew their American Heart Association certification.",
+      "overview": "This renewal course reinforces systematic assessment, cardiac arrest algorithms, rhythm and medication concepts, airway and ventilation decisions, stroke recognition, post-cardiac-arrest care and high-performance team communication through focused skills and team scenarios.",
+      "credential": "Successful participants receive an American Heart Association ACLS Provider course completion card, valid for two years."
+    },
+    "aha_pals_provider": {
+      "audience": "Designed for healthcare professionals who respond to respiratory, shock and cardiopulmonary emergencies involving infants and children.",
+      "overview": "This initial PALS course uses skills stations and team scenarios to cover pediatric assessment, respiratory emergencies, shock, rhythm disturbances, cardiac arrest and effective team-based response.",
+      "credential": "Successful participants receive an American Heart Association PALS Provider course completion card, valid for two years."
+    },
+    "aha_pals_renewal": {
+      "audience": "Designed for current or recently expired PALS providers who need to renew their American Heart Association certification.",
+      "overview": "This renewal course reinforces pediatric assessment, respiratory emergencies, shock, rhythm disturbances, cardiac arrest and effective team-based response through focused skills and scenarios.",
+      "credential": "Successful participants receive an American Heart Association PALS Provider course completion card, valid for two years."
+    },
+    "aha_family_friends_cpr": {
+      "audience": "Designed for family members, friends and community members who want practical CPR and emergency-response skills without needing a workplace certification card.",
+      "overview": "This instructor-led awareness course provides hands-on practice in adult and child CPR, AED use and choking response in a relaxed community setting.",
+      "credential": "Family & Friends CPR is an educational participation course and does not issue an American Heart Association course completion card."
+    }
+  }
+}

--- a/data/linkedin_event_sync.json
+++ b/data/linkedin_event_sync.json
@@ -5,6 +5,21 @@
     "::"
   ],
   "promoted_session_ids": [],
+  "course_images": {
+    "209805": "docs/images/HS-CPR-AED.jpeg",
+    "209806": "docs/images/zoom-bls-aha.png",
+    "209808": "docs/images/HS-CPR-AED.jpeg",
+    "209809": "docs/images/HS-FA-CPR-AED.jpeg",
+    "209818": "docs/images/HS-PEDI-FA-CPR-AED.jpeg",
+    "210549": "docs/images/zoom-bls-aha.png",
+    "241108": "docs/images/25-acls-new.png",
+    "251496": "docs/images/25-pals-new.png",
+    "251545": "docs/images/HS-PEDI-FA-CPR-AED.jpeg",
+    "252737": "docs/images/family-and-friends-CPR.jpg",
+    "329495": "docs/images/HS-FA-CPR-AED.jpeg",
+    "351632": "docs/images/HS-PEDI-FA-CPR-AED.jpeg",
+    "359474": "docs/images/zoom-bls-aha.png"
+  },
   "location_addresses": {
     ":: Wilmington; Shipyard Blvd": {
       "line1": "4018 Shipyard Blvd",

--- a/scripts/linkedin_event_sync.py
+++ b/scripts/linkedin_event_sync.py
@@ -24,6 +24,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SCHEDULE = ROOT / "docs/data/schedule_future.json"
 DEFAULT_CONFIG = ROOT / "data/linkedin_event_sync.json"
+DEFAULT_DESCRIPTIONS = ROOT / "data/course_descriptions.json"
 DEFAULT_STATE = ROOT / "data/runtime/linkedin_event_state.json"
 
 
@@ -57,11 +58,23 @@ class PlannedEvent:
     fingerprint: str
 
 
-def event_description(session: dict[str, Any]) -> str:
-    parts = [
-        session.get("mapped_short_description") or session.get("course_name"),
-        "View details and register through 910CPR.",
-    ]
+def event_description(session: dict[str, Any], descriptions: dict[str, Any], address: dict[str, str]) -> str:
+    copy = descriptions.get("courses", {}).get(session.get("course_key"), {})
+    parts = [copy.get("audience"), copy.get("overview"), copy.get("preparation"), copy.get("credential")]
+    if not any(parts):
+        parts = [
+            session.get("mapped_who_class_for"),
+            session.get("mapped_what_to_expect") or session.get("mapped_short_description"),
+            session.get("mapped_prerequisites"),
+            session.get("mapped_certification_card"),
+        ]
+    location = ", ".join(
+        value for value in [address.get("line1"), address.get("city"), address.get("geographicArea")] if value
+    )
+    parts.extend([
+        f"Location: 910CPR, {location}",
+        "Choose this class date and register using the event link.",
+    ])
     return "\n\n".join(part.strip() for part in parts if part and part.strip())
 
 
@@ -94,7 +107,7 @@ def eligible(session: dict[str, Any], config: dict[str, Any]) -> tuple[bool, str
     return True, "promoted override" if promoted else "public seated class"
 
 
-def build_event(session: dict[str, Any], config: dict[str, Any]) -> PlannedEvent:
+def build_event(session: dict[str, Any], config: dict[str, Any], descriptions: dict[str, Any] | None = None) -> PlannedEvent:
     location = normalized_location(session.get("location_display") or session.get("location_name"))
     session_id = str(session["session_id"])
     course_id = str(session.get("course_id") or "")
@@ -103,9 +116,10 @@ def build_event(session: dict[str, Any], config: dict[str, Any]) -> PlannedEvent
     image_urn = config.get("background_image_urn") or os.getenv("LINKEDIN_EVENT_BACKGROUND_IMAGE_URN")
     if not organizer:
         organizer = "urn:li:organization:REQUIRED"
+    address = address_for(location, config)
     payload: dict[str, Any] = {
         "name": {"localized": {"en_US": session.get("mapped_clean_title") or session["course_name"]}},
-        "description": {"localized": {"en_US": {"rawText": event_description(session)}}},
+        "description": {"localized": {"en_US": {"rawText": event_description(session, descriptions or {}, address)}}},
         "organizer": organizer,
         "startsAt": epoch_ms(session["start_at"]),
         "discoveryMode": "LISTED",
@@ -113,7 +127,7 @@ def build_event(session: dict[str, Any], config: dict[str, Any]) -> PlannedEvent
             "inPerson": {
                 "endsAt": epoch_ms(session["end_at"]),
                 "url": session["registration_url"],
-                "address": address_for(location, config),
+                "address": address,
                 "venueDetails": {"localized": {"en_US": {"rawText": location.removeprefix("::").strip()}}},
             }
         },
@@ -246,15 +260,16 @@ def event_registration_url(remote: dict[str, Any]) -> str | None:
     return remote.get("type", {}).get("inPerson", {}).get("url")
 
 
-def plan(schedule_path: Path, config_path: Path) -> tuple[list[PlannedEvent], list[dict[str, str]]]:
+def plan(schedule_path: Path, config_path: Path, descriptions_path: Path = DEFAULT_DESCRIPTIONS) -> tuple[list[PlannedEvent], list[dict[str, str]]]:
     schedule = load_json(schedule_path)
     config = load_json(config_path)
+    descriptions = load_json(descriptions_path, default={"courses": {}})
     events: list[PlannedEvent] = []
     skipped: list[dict[str, str]] = []
     for session in schedule.get("sessions", []):
         ok, reason = eligible(session, config)
         if ok:
-            events.append(build_event(session, config))
+            events.append(build_event(session, config, descriptions))
         else:
             skipped.append({"session_id": str(session.get("session_id") or ""), "reason": reason})
     return events, skipped
@@ -269,6 +284,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--schedule", type=Path, default=DEFAULT_SCHEDULE)
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--descriptions", type=Path, default=DEFAULT_DESCRIPTIONS)
     parser.add_argument("--state", type=Path, default=DEFAULT_STATE)
     parser.add_argument("--apply", action="store_true")
     parser.add_argument("--output", type=Path)
@@ -276,7 +292,7 @@ def main() -> int:
     parser.add_argument("--max-events", type=int, default=0, help="Maximum changed events to write; 0 means unlimited")
     args = parser.parse_args()
 
-    events, skipped = plan(args.schedule, args.config)
+    events, skipped = plan(args.schedule, args.config, args.descriptions)
     if args.session_id:
         events = [event for event in events if event.session_id == args.session_id]
     report: dict[str, Any] = {

--- a/scripts/linkedin_event_sync.py
+++ b/scripts/linkedin_event_sync.py
@@ -13,6 +13,7 @@ import json
 import os
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -49,6 +50,8 @@ def normalized_location(value: str | None) -> str:
 @dataclass(frozen=True)
 class PlannedEvent:
     session_id: str
+    course_id: str
+    image_path: str | None
     payload: dict[str, Any]
     post_payload: dict[str, Any]
     fingerprint: str
@@ -94,6 +97,8 @@ def eligible(session: dict[str, Any], config: dict[str, Any]) -> tuple[bool, str
 def build_event(session: dict[str, Any], config: dict[str, Any]) -> PlannedEvent:
     location = normalized_location(session.get("location_display") or session.get("location_name"))
     session_id = str(session["session_id"])
+    course_id = str(session.get("course_id") or "")
+    image_path = config.get("course_images", {}).get(course_id)
     organizer = config.get("organizer_urn") or os.getenv("LINKEDIN_ORGANIZATION_URN")
     image_urn = config.get("background_image_urn") or os.getenv("LINKEDIN_EVENT_BACKGROUND_IMAGE_URN")
     if not organizer:
@@ -130,7 +135,7 @@ def build_event(session: dict[str, Any], config: dict[str, Any]) -> PlannedEvent
     }
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     fingerprint = hashlib.sha256(canonical.encode()).hexdigest()
-    return PlannedEvent(session_id, payload, post_payload, fingerprint)
+    return PlannedEvent(session_id, course_id, image_path, payload, post_payload, fingerprint)
 
 
 class LinkedInClient:
@@ -138,7 +143,7 @@ class LinkedInClient:
         self.token = token
         self.version = version
 
-    def request(self, method: str, path: str, payload: dict[str, Any], restli_method: str | None = None) -> tuple[int, dict[str, str], Any]:
+    def request(self, method: str, path: str, payload: dict[str, Any] | None = None, restli_method: str | None = None) -> tuple[int, dict[str, str], Any]:
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Accept": "application/json",
@@ -150,7 +155,7 @@ class LinkedInClient:
             headers["X-RestLi-Method"] = restli_method
         request = urllib.request.Request(
             f"https://api.linkedin.com/rest/{path}",
-            data=json.dumps(payload).encode(),
+            data=json.dumps(payload).encode() if payload is not None else None,
             headers=headers,
             method=method,
         )
@@ -178,6 +183,67 @@ class LinkedInClient:
     def update_event(self, event_id: str, payload: dict[str, Any]) -> None:
         mutable = {k: v for k, v in payload.items() if k not in {"organizer"}}
         self.request("POST", f"events/{event_id}", {"patch": {"$set": mutable}}, "partial_update")
+
+    def find_upcoming_events(self, organizer: str) -> list[dict[str, Any]]:
+        encoded = urllib.parse.quote(organizer, safe="")
+        path = (
+            "events?q=eventsByOrganizer"
+            f"&organizer={encoded}&start=0&count=100&excludeCancelled=true"
+            "&timeBasedFilter=(lifeCycleState:UPCOMING)&entryCriteria=PUBLIC"
+            "&sortOrder=START_TIME_ASC"
+        )
+        _, _, body = self.request("GET", path)
+        return (body or {}).get("elements", [])
+
+    def upload_event_image(self, image_path: Path, owner: str) -> str:
+        register = {
+            "registerUploadRequest": {
+                "owner": owner,
+                "recipes": ["urn:li:digitalmediaRecipe:event-background-image"],
+                "serviceRelationships": [{
+                    "identifier": "urn:li:userGeneratedContent",
+                    "relationshipType": "OWNER",
+                }],
+                "supportedUploadMechanism": ["SYNCHRONOUS_UPLOAD"],
+            }
+        }
+        _, _, body = self.request("POST", "assets?action=registerUpload", register)
+        value = (body or {}).get("value", {})
+        mechanism = value.get("uploadMechanism", {}).get(
+            "com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest", {}
+        )
+        upload_url = mechanism.get("uploadUrl")
+        asset = value.get("asset")
+        if not upload_url or not asset:
+            raise RuntimeError("LinkedIn did not return an event image upload URL and asset URN")
+        content_type = "image/png" if image_path.suffix.lower() == ".png" else "image/jpeg"
+        upload_request = urllib.request.Request(
+            upload_url,
+            data=image_path.read_bytes(),
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": content_type,
+                "X-Restli-Protocol-Version": "2.0.0",
+                "Linkedin-Version": self.version,
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(upload_request, timeout=60):
+                pass
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"LinkedIn image upload failed ({exc.code}): {detail}") from exc
+        return str(asset)
+
+
+def event_fingerprint(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def event_registration_url(remote: dict[str, Any]) -> str | None:
+    return remote.get("type", {}).get("inPerson", {}).get("url")
 
 
 def plan(schedule_path: Path, config_path: Path) -> tuple[list[PlannedEvent], list[dict[str, str]]]:
@@ -230,11 +296,41 @@ def main() -> int:
     token = os.getenv("LINKEDIN_ACCESS_TOKEN")
     if not token:
         raise SystemExit("LINKEDIN_ACCESS_TOKEN is required with --apply")
-    state = load_json(args.state, default={"sessions": {}})
+    state = load_json(args.state, default={"sessions": {}, "assets": {}})
+    state.setdefault("sessions", {})
+    state.setdefault("assets", {})
     client = LinkedInClient(token, os.getenv("LINKEDIN_API_VERSION", "202607"))
+    organizer = os.getenv("LINKEDIN_ORGANIZATION_URN") or load_json(args.config).get("organizer_urn")
+    remote_by_url = {
+        event_registration_url(remote): remote
+        for remote in client.find_upcoming_events(organizer)
+        if event_registration_url(remote)
+    }
     actions: list[dict[str, str]] = []
     changed = 0
     for event in events:
+        registration_url = event.payload["type"]["inPerson"]["url"]
+        if event.session_id not in state["sessions"] and registration_url in remote_by_url:
+            remote = remote_by_url[registration_url]
+            state["sessions"][event.session_id] = {
+                "event_id": str(remote["id"]),
+                "post_id": remote.get("ugcPost"),
+                "fingerprint": "",
+            }
+            save_state(args.state, state)
+
+        if event.image_path:
+            asset = state["assets"].get(event.image_path)
+            if not asset:
+                image_file = ROOT / event.image_path
+                if not image_file.is_file():
+                    raise RuntimeError(f"Configured LinkedIn event image does not exist: {image_file}")
+                asset = client.upload_event_image(image_file, event.payload["organizer"])
+                state["assets"][event.image_path] = asset
+                save_state(args.state, state)
+            event.payload["backgroundImage"] = asset
+            object.__setattr__(event, "fingerprint", event_fingerprint(event.payload))
+
         existing = state["sessions"].get(event.session_id)
         if existing and existing.get("fingerprint") == event.fingerprint:
             actions.append({"session_id": event.session_id, "action": "unchanged"})

--- a/tests/test_linkedin_event_sync.py
+++ b/tests/test_linkedin_event_sync.py
@@ -69,6 +69,23 @@ def test_payload_uses_session_times_registration_and_address():
     assert event.image_path == "docs/images/zoom-bls-aha.png"
 
 
+def test_rich_course_description_includes_audience_credential_and_location():
+    descriptions = {
+        "courses": {
+            "aha_bls_provider": {
+                "audience": "For healthcare professionals.",
+                "overview": "Hands-on adult, child and infant CPR practice.",
+                "credential": "AHA BLS Provider card valid for two years.",
+            }
+        }
+    }
+    event = MODULE.build_event(session(course_key="aha_bls_provider"), CONFIG, descriptions)
+    text = event.payload["description"]["localized"]["en_US"]["rawText"]
+    assert "For healthcare professionals." in text
+    assert "valid for two years" in text
+    assert "4018 Shipyard Blvd, Wilmington, North Carolina" in text
+
+
 def test_remote_event_registration_url_is_detected():
     remote = {"type": {"inPerson": {"url": "https://example.test/enroll?id=99"}}}
     assert MODULE.event_registration_url(remote).endswith("id=99")

--- a/tests/test_linkedin_event_sync.py
+++ b/tests/test_linkedin_event_sync.py
@@ -16,6 +16,7 @@ CONFIG = {
     "background_image_urn": "urn:li:digitalmediaAsset:456",
     "public_location_prefixes": ["::"],
     "promoted_session_ids": [],
+    "course_images": {"209806": "docs/images/zoom-bls-aha.png"},
     "location_addresses": {
         ":: Wilmington; Shipyard Blvd": {
             "line1": "4018 Shipyard Blvd",
@@ -31,6 +32,7 @@ CONFIG = {
 def session(**overrides):
     base = {
         "session_id": "99",
+        "course_id": "209806",
         "course_name": "AHA BLS Provider",
         "mapped_clean_title": "AHA BLS Provider",
         "mapped_short_description": "Hands-on BLS training.",
@@ -64,6 +66,12 @@ def test_payload_uses_session_times_registration_and_address():
     assert event.payload["type"]["inPerson"]["url"].endswith("id=99")
     assert event.payload["type"]["inPerson"]["address"]["line1"] == "4018 Shipyard Blvd"
     assert event.payload["backgroundImage"] == "urn:li:digitalmediaAsset:456"
+    assert event.image_path == "docs/images/zoom-bls-aha.png"
+
+
+def test_remote_event_registration_url_is_detected():
+    remote = {"type": {"inPerson": {"url": "https://example.test/enroll?id=99"}}}
+    assert MODULE.event_registration_url(remote).endswith("id=99")
 
 
 def test_promoted_session_can_override_nonpublic_flag_but_not_location_mapping():


### PR DESCRIPTION
## Summary
- map public course IDs to their matching 910CPR course images
- register and upload LinkedIn event-background assets before event creation
- recover already-created LinkedIn events by their Enrollware registration URL
- persist event and image asset IDs so later batches update instead of duplicate
- correctly commit a newly created state file from GitHub Actions

## Validation
- Python compilation passed
- all five targeted synchronization tests passed
- dry run still finds 37 eligible sessions and excludes 2 closed sessions

## Rollout
After merging, run with `apply=true` and `max_events=1`. The workflow should discover the existing Heartsaver event, upload its course image, update it, and record its event ID without creating a duplicate.