### PR TITLE
Build durable SEO landers for every public session

### DIFF
--- a/docs/classes/13828438.html
+++ b/docs/classes/13828438.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 12, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828438.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 12, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-12T14:00:00-04:00",
   "endDate": "2026-08-12T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 12, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828438",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct241108" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828442" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828449" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828446" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828447" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828448" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828450" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828438",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828439.html
+++ b/docs/classes/13828439.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 13, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828439.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 13, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-13T14:00:00-04:00",
   "endDate": "2026-08-13T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 13, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828439",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct241108" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828446" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828447" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828448" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828449" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828450" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828439",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828440.html
+++ b/docs/classes/13828440.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 17, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828440.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 17, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-17T14:00:00-04:00",
   "endDate": "2026-08-17T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 17, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828440",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct241108" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828447" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828446" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828450" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828448" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828449" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828440",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828441.html
+++ b/docs/classes/13828441.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA ACLS Provider Course on Tuesday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="AHA ACLS Provider Course on Tuesday in Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 18, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828441.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA ACLS Provider Course on Tuesday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 18, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-18T14:00:00-04:00",
   "endDate": "2026-08-18T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 18, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828441",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct241108" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828448" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828446" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828447" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828449" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828450" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828441",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828442.html
+++ b/docs/classes/13828442.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 26, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828442.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 26, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-26T14:00:00-04:00",
   "endDate": "2026-08-26T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 26, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828442",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct241108" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828449" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828446" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828447" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828448" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828450" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828442",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828443.html
+++ b/docs/classes/13828443.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 31, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828443.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA ACLS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 31, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-31T14:00:00-04:00",
   "endDate": "2026-08-31T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 31, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828443",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct241108" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828440" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828447" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828446" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828450" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828448" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828449" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828443",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct241108",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828445.html
+++ b/docs/classes/13828445.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA ACLS Renewal Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="Afternoon AHA ACLS Renewal Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 12, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828445.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA ACLS Renewal Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 12, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-12T14:00:00-04:00",
   "endDate": "2026-08-12T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 12, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828445",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209818" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828449" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828442" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828439" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828440" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828441" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828443" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828445",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828446.html
+++ b/docs/classes/13828446.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Thursday Afternoon AHA ACLS Renewal Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Thursday Afternoon AHA ACLS Renewal Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 13, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828446.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Thursday Afternoon AHA ACLS Renewal Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 13, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-13T14:00:00-04:00",
   "endDate": "2026-08-13T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 13, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828446",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209818" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828439" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828440" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828441" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828442" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828443" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828446",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828447.html
+++ b/docs/classes/13828447.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA ACLS Renewal Course on Monday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="AHA ACLS Renewal Course on Monday in Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 17, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828447.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA ACLS Renewal Course on Monday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 17, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-17T14:00:00-04:00",
   "endDate": "2026-08-17T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 17, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828447",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209818" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828440" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828439" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828443" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828441" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828442" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828447",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828448.html
+++ b/docs/classes/13828448.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA ACLS Renewal Course on Tuesday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="AHA ACLS Renewal Course on Tuesday in Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 18, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828448.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA ACLS Renewal Course on Tuesday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 18, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-18T14:00:00-04:00",
   "endDate": "2026-08-18T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 18, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828448",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209818" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828441" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828439" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828440" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828442" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828443" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828448",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828449.html
+++ b/docs/classes/13828449.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Wednesday Afternoon AHA ACLS Renewal Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="Wednesday Afternoon AHA ACLS Renewal Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 26, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828449.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Wednesday Afternoon AHA ACLS Renewal Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 26, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-26T14:00:00-04:00",
   "endDate": "2026-08-26T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 26, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828449",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209818" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828445" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828450.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828442" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828439" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828440" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828441" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828443" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828449",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828450.html
+++ b/docs/classes/13828450.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA ACLS Renewal Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Afternoon AHA ACLS Renewal Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="ACLS session in Wilmington, NC on August 31, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828450.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA ACLS Renewal Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="ACLS session in Wilmington, NC on August 31, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-31T14:00:00-04:00",
   "endDate": "2026-08-31T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "ACLS in Wilmington on August 31, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association ACLS Provider course for clinicians involved in adult cardiovascular emergency care. The class reinforces systematic assessment, effective team dynamics, rhythm recognition, pharmacology concepts, stroke recognition, and management of cardiac arrest and peri-arrest situations. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828450",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209818" data-empty-link-label="See upcoming ACLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest ACLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828447" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828447.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828445.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828446.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828448.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828449.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828440" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828440.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828438" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828438.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828439" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828439.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828443" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828443.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828441" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828441.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828442" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828442.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for nurses, paramedics, respiratory therapists, physicians, advanced-practice providers, and clinical teams involved in adult cardiac emergency response.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828450",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209818",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828454.html
+++ b/docs/classes/13828454.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Wednesday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Wednesday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 12, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828454.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Wednesday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 12, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-12T14:00:00-04:00",
   "endDate": "2026-08-12T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 12, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828454",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209805" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828458" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828465" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828462" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828463" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828464" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828466" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828454",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828455.html
+++ b/docs/classes/13828455.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA PALS Provider Course on Thursday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="AHA PALS Provider Course on Thursday in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 13, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828455.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA PALS Provider Course on Thursday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 13, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-13T14:00:00-04:00",
   "endDate": "2026-08-13T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 13, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828455",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209805" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828462" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828463" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828464" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828465" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828466" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828455",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828456.html
+++ b/docs/classes/13828456.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA PALS Provider Course on Monday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="AHA PALS Provider Course on Monday in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 17, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828456.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA PALS Provider Course on Monday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 17, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-17T14:00:00-04:00",
   "endDate": "2026-08-17T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 17, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828456",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209805" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828463" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828462" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828466" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828464" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828465" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828456",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828457.html
+++ b/docs/classes/13828457.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Tuesday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Tuesday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 18, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828457.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Tuesday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 18, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-18T14:00:00-04:00",
   "endDate": "2026-08-18T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 18, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828457",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209805" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828464" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828462" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828463" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828465" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828466" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828457",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828458.html
+++ b/docs/classes/13828458.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA PALS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Afternoon AHA PALS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 26, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828458.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA PALS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 26, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-26T14:00:00-04:00",
   "endDate": "2026-08-26T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 26, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828458",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209805" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828465" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828462" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828463" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828464" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828466" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828458",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828459.html
+++ b/docs/classes/13828459.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Monday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="Monday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 31, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828459.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Monday Afternoon AHA PALS Provider Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 31, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-31T14:00:00-04:00",
   "endDate": "2026-08-31T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 31, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828459",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209805" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828456" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828463" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828462" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828466" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828464" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828465" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828459",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209805",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828461.html
+++ b/docs/classes/13828461.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA PALS Renewal Course on Wednesday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="AHA PALS Renewal Course on Wednesday in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 12, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828461.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA PALS Renewal Course on Wednesday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 12, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-12T14:00:00-04:00",
   "endDate": "2026-08-12T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 12, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828461",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct251496" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828465" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828458" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828455" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828456" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828457" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828459" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828461",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828462.html
+++ b/docs/classes/13828462.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Thursday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Thursday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 13, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828462.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Thursday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 13, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-13T14:00:00-04:00",
   "endDate": "2026-08-13T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 13, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828462",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct251496" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828455" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828456" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828457" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828458" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828459" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828462",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828463.html
+++ b/docs/classes/13828463.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA PALS Renewal Course on Monday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="AHA PALS Renewal Course on Monday in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 17, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828463.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA PALS Renewal Course on Monday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 17, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-17T14:00:00-04:00",
   "endDate": "2026-08-17T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 17, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828463",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct251496" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828456" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828455" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828459" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828457" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828458" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828463",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828464.html
+++ b/docs/classes/13828464.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA PALS Renewal Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="Afternoon AHA PALS Renewal Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 18, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828464.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA PALS Renewal Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 18, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-18T14:00:00-04:00",
   "endDate": "2026-08-18T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 18, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828464",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct251496" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828457" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828455" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828456" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828458" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828459" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828464",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828465.html
+++ b/docs/classes/13828465.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Wednesday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Wednesday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 26, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828465.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Wednesday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 26, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-26T14:00:00-04:00",
   "endDate": "2026-08-26T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 26, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828465",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct251496" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828461" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 31, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828466.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828458" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828455" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828456" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828457" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828459" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828465",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13828466.html
+++ b/docs/classes/13828466.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Monday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Monday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="PALS session in Wilmington, NC on August 31, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13828466.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Monday Afternoon AHA PALS Renewal Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="PALS session in Wilmington, NC on August 31, 2026 at 2:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-31T14:00:00-04:00",
   "endDate": "2026-08-31T18:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "PALS in Wilmington on August 31, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association PALS Provider course for clinicians who respond to pediatric respiratory, shock, and cardiac emergencies. The class emphasizes pediatric assessment, respiratory support, high-performance team response, and treatment priorities for infants and children in urgent care settings. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. Advanced courses keep recognition, assessment, and coordinated response at the center of the scenario, including respiratory emergencies and time-sensitive cardiovascular care.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13828466",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct251496" data-empty-link-label="See upcoming PALS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest PALS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13828463" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828463.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 12, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828461.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828462.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 18, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828464.html">Book This Class</a>
   </div>
@@ -278,9 +272,69 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 26, 2026</div>
   <div class="upcoming-time">2:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13828465.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828456" data-start="2026-08-17T14:00:00-04:00" data-end="2026-08-17T18:00:00-04:00" data-session-start="2026-08-17T14:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828456.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828454" data-start="2026-08-12T14:00:00-04:00" data-end="2026-08-12T18:00:00-04:00" data-session-start="2026-08-12T14:00:00-04:00">
+  <div class="upcoming-date">August 12, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828454.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828455" data-start="2026-08-13T14:00:00-04:00" data-end="2026-08-13T18:00:00-04:00" data-session-start="2026-08-13T14:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828455.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828459" data-start="2026-08-31T14:00:00-04:00" data-end="2026-08-31T18:00:00-04:00" data-session-start="2026-08-31T14:00:00-04:00">
+  <div class="upcoming-date">August 31, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828459.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828457" data-start="2026-08-18T14:00:00-04:00" data-end="2026-08-18T18:00:00-04:00" data-session-start="2026-08-18T14:00:00-04:00">
+  <div class="upcoming-date">August 18, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828457.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13828458" data-start="2026-08-26T14:00:00-04:00" data-end="2026-08-26T18:00:00-04:00" data-session-start="2026-08-26T14:00:00-04:00">
+  <div class="upcoming-date">August 26, 2026</div>
+  <div class="upcoming-time">2:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13828458.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +345,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for pediatric, emergency, transport, ICU, and clinical roles that may respond to seriously ill or injured infants and children.</p>
@@ -325,7 +389,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +408,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13828466",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct251496",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13847870.html
+++ b/docs/classes/13847870.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA BLS Provider Course on Friday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="AHA BLS Provider Course on Friday in Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 14, 2026 at 10:00 AM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13847870.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA BLS Provider Course on Friday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 14, 2026 at 10:00 AM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-14T10:00:00-04:00",
   "endDate": "2026-08-14T12:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 14, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider course for healthcare providers and students entering clinical programs. The class covers high-quality CPR, AED use, ventilations, choking response, and team-based basic life support for adult, child, and infant patients. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13847870",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209806" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">10:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">11:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">8:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">12:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13887884" data-start="2026-08-17T09:00:00-04:00" data-end="2026-08-17T11:00:00-04:00" data-session-start="2026-08-17T09:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">9:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870445" data-start="2026-08-08T12:30:00-04:00" data-end="2026-08-08T14:30:00-04:00" data-session-start="2026-08-08T12:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">12:30 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13850189" data-start="2026-08-10T13:00:00-04:00" data-end="2026-08-10T15:00:00-04:00" data-session-start="2026-08-10T13:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">1:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13895945" data-start="2026-08-10T15:00:00-04:00" data-end="2026-08-10T17:00:00-04:00" data-session-start="2026-08-10T15:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">3:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13865036" data-start="2026-08-11T19:00:00-04:00" data-end="2026-08-11T21:00:00-04:00" data-session-start="2026-08-11T19:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">7:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13847870",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13850189.html
+++ b/docs/classes/13850189.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA BLS Renewal Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Afternoon AHA BLS Renewal Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 10, 2026 at 1:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13850189.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA BLS Renewal Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 10, 2026 at 1:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-10T13:00:00-04:00",
   "endDate": "2026-08-10T15:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 10, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider renewal class for students who already work at the healthcare-provider level and need to keep their BLS current. The class focuses on high-quality CPR, AED use, ventilations, choking response, and team response for adult, child, and infant emergencies. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13850189",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct359474" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13895945" data-start="2026-08-10T15:00:00-04:00" data-end="2026-08-10T17:00:00-04:00" data-session-start="2026-08-10T15:00:00-04:00">
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">3:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">12:30 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">9:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">7:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13888037" data-start="2026-08-17T11:00:00-04:00" data-end="2026-08-17T13:00:00-04:00" data-session-start="2026-08-17T11:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">12:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13847870" data-start="2026-08-14T10:00:00-04:00" data-end="2026-08-14T12:00:00-04:00" data-session-start="2026-08-14T10:00:00-04:00">
+  <div class="upcoming-date">August 14, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13889121" data-start="2026-08-11T08:00:00-04:00" data-end="2026-08-11T10:00:00-04:00" data-session-start="2026-08-11T08:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">8:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13850189",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13852838.html
+++ b/docs/classes/13852838.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Morning AHA BLS HeartCode Skills Session - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Morning AHA BLS HeartCode Skills Session - Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 24, 2026 at 9:45 AM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13852838.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Morning AHA BLS HeartCode Skills Session - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 24, 2026 at 9:45 AM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-24T09:45:00-04:00",
   "endDate": "2026-08-24T10:45:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 24, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider HeartCode skills session. Students complete the AHA online HeartCode BLS coursework first, then use this appointment for hands-on skills practice and testing. It is built for healthcare and clinical roles that need AHA BLS Provider certification while using the blended-learning pathway, including high-quality CPR, AED use, ventilation practice, choking response, and team communication. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13852838",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct210549" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">11:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">9:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">11:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">1:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13895945" data-start="2026-08-10T15:00:00-04:00" data-end="2026-08-10T17:00:00-04:00" data-session-start="2026-08-10T15:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">3:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13847870" data-start="2026-08-14T10:00:00-04:00" data-end="2026-08-14T12:00:00-04:00" data-session-start="2026-08-14T10:00:00-04:00">
+  <div class="upcoming-date">August 14, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870445" data-start="2026-08-08T12:30:00-04:00" data-end="2026-08-08T14:30:00-04:00" data-session-start="2026-08-08T12:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">12:30 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13889121" data-start="2026-08-11T08:00:00-04:00" data-end="2026-08-11T10:00:00-04:00" data-session-start="2026-08-11T08:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">8:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">12:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13865036" data-start="2026-08-11T19:00:00-04:00" data-end="2026-08-11T21:00:00-04:00" data-session-start="2026-08-11T19:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">7:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13852838",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct210549",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct210549",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13857862.html
+++ b/docs/classes/13857862.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Monday Evening AHA Heartsaver Class in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Monday Evening AHA Heartsaver Class in Wilmington NC | 910CPR">
 <meta property="og:description" content="Heartsaver session in Wilmington, NC on August 17, 2026 at 6:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13857862.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Monday Evening AHA Heartsaver Class in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="Heartsaver session in Wilmington, NC on August 17, 2026 at 6:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-17T18:00:00-04:00",
   "endDate": "2026-08-17T20:30:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "Heartsaver in Wilmington on August 17, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This AHA Heartsaver First Aid CPR AED class is for workplace, school, childcare, fitness, church, and community responders. It combines first aid, CPR, AED, choking, opioid emergency awareness, stroke recognition, seizure response, asthma assistance, burns, environmental emergencies, and other practical response skills for people who need a recognized non-healthcare-provider certification. First aid content is framed around fast recognition, EMS activation, and practical action while help is on the way. Choking response follows the current pattern: adults and children receive 5 back blows and 5 abdominal thrusts; infants receive 5 back blows and 5 chest thrusts. Opioid emergency content highlights recognition, naloxone availability, CPR with breaths for respiratory arrest, and why hands-only CPR may not be enough. Stroke content uses FAST recognition, urgent EMS activation, and avoids treating stroke as an older-adult-only problem. Seizure response focuses on protecting from injury, not restraining the person, placing nothing in the mouth, and calling EMS for prolonged, repeated, first-time, injured, breathing-compromised, water-related, pregnant, diabetic, or pediatric febrile seizure concerns. Asthma support includes helping with the person's prescribed bronchodilator, using a spacer when available, and understanding that an improvised spacer may help when a standard spacer is not available. Environmental first aid includes rapid cooling for severe heat illness, ice water immersion when available, safe rewarming for cold exposure, and avoiding harmful warming methods. Additional first aid topics include ticks, stings, burns, eye injuries, poison ivy/oak exposure, and pulse oximetry limitations.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13857862",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -232,19 +224,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="/heartsaver.html" data-empty-link-label="See upcoming Heartsaver classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest Heartsaver class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13870561" data-start="2026-08-14T12:00:00-04:00" data-end="2026-08-14T14:30:00-04:00" data-session-start="2026-08-14T12:00:00-04:00">
   <div class="upcoming-date">August 14, 2026</div>
   <div class="upcoming-time">12:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870561.html">Book This Class</a>
   </div>
@@ -254,7 +248,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 14, 2026</div>
   <div class="upcoming-time">2:30 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13872968.html">Book This Class</a>
   </div>
@@ -267,10 +261,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for teachers, childcare staff, fitness professionals, security teams, office staff, church teams, construction crews, and other workplace responders.</p>
@@ -301,7 +305,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -320,7 +324,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13857862",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209809",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209809",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13861222.html
+++ b/docs/classes/13861222.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA BLS Renewal Course on Saturday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="AHA BLS Renewal Course on Saturday in Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 08, 2026 at 10:30 AM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13861222.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA BLS Renewal Course on Saturday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 08, 2026 at 10:30 AM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-08T10:30:00-04:00",
   "endDate": "2026-08-08T12:30:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 08, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider renewal class for students who already work at the healthcare-provider level and need to keep their BLS current. The class focuses on high-quality CPR, AED use, ventilations, choking response, and team response for adult, child, and infant emergencies. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13861222",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct359474" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13870445" data-start="2026-08-08T12:30:00-04:00" data-end="2026-08-08T14:30:00-04:00" data-session-start="2026-08-08T12:30:00-04:00">
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">12:30 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">1:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">9:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">3:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">7:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13847870" data-start="2026-08-14T10:00:00-04:00" data-end="2026-08-14T12:00:00-04:00" data-session-start="2026-08-14T10:00:00-04:00">
+  <div class="upcoming-date">August 14, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13888037" data-start="2026-08-17T11:00:00-04:00" data-end="2026-08-17T13:00:00-04:00" data-session-start="2026-08-17T11:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13889121" data-start="2026-08-11T08:00:00-04:00" data-end="2026-08-11T10:00:00-04:00" data-session-start="2026-08-11T08:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">8:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">12:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13861222",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13865036.html
+++ b/docs/classes/13865036.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Evening AHA BLS Renewal Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Evening AHA BLS Renewal Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 11, 2026 at 7:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13865036.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Evening AHA BLS Renewal Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 11, 2026 at 7:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-11T19:00:00-04:00",
   "endDate": "2026-08-11T21:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 11, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider renewal class for students who already work at the healthcare-provider level and need to keep their BLS current. The class focuses on high-quality CPR, AED use, ventilations, choking response, and team response for adult, child, and infant emergencies. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13865036",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct359474" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13861222" data-start="2026-08-08T10:30:00-04:00" data-end="2026-08-08T12:30:00-04:00" data-session-start="2026-08-08T10:30:00-04:00">
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">12:30 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">1:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">3:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">9:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13889121" data-start="2026-08-11T08:00:00-04:00" data-end="2026-08-11T10:00:00-04:00" data-session-start="2026-08-11T08:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">8:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">12:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13847870" data-start="2026-08-14T10:00:00-04:00" data-end="2026-08-14T12:00:00-04:00" data-session-start="2026-08-14T10:00:00-04:00">
+  <div class="upcoming-date">August 14, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13888037" data-start="2026-08-17T11:00:00-04:00" data-end="2026-08-17T13:00:00-04:00" data-session-start="2026-08-17T11:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13865036",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13870445.html
+++ b/docs/classes/13870445.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Weekend AHA BLS Renewal Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Weekend AHA BLS Renewal Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 08, 2026 at 12:30 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13870445.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Weekend AHA BLS Renewal Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 08, 2026 at 12:30 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-08T12:30:00-04:00",
   "endDate": "2026-08-08T14:30:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 08, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider renewal class for students who already work at the healthcare-provider level and need to keep their BLS current. The class focuses on high-quality CPR, AED use, ventilations, choking response, and team response for adult, child, and infant emergencies. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13870445",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct359474" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13861222" data-start="2026-08-08T10:30:00-04:00" data-end="2026-08-08T12:30:00-04:00" data-session-start="2026-08-08T10:30:00-04:00">
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">1:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">3:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">7:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">9:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">12:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13847870" data-start="2026-08-14T10:00:00-04:00" data-end="2026-08-14T12:00:00-04:00" data-session-start="2026-08-14T10:00:00-04:00">
+  <div class="upcoming-date">August 14, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13888037" data-start="2026-08-17T11:00:00-04:00" data-end="2026-08-17T13:00:00-04:00" data-session-start="2026-08-17T11:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13889121" data-start="2026-08-11T08:00:00-04:00" data-end="2026-08-11T10:00:00-04:00" data-session-start="2026-08-11T08:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">8:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13870445",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13870561.html
+++ b/docs/classes/13870561.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA Heartsaver Class - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Afternoon AHA Heartsaver Class - Wilmington NC | 910CPR">
 <meta property="og:description" content="Heartsaver session in Wilmington, NC on August 14, 2026 at 12:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13870561.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA Heartsaver Class - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="Heartsaver session in Wilmington, NC on August 14, 2026 at 12:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-14T12:00:00-04:00",
   "endDate": "2026-08-14T14:30:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "Heartsaver in Wilmington on August 14, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This AHA Heartsaver First Aid CPR AED class is for workplace, school, childcare, fitness, church, and community responders. It combines first aid, CPR, AED, choking, opioid emergency awareness, stroke recognition, seizure response, asthma assistance, burns, environmental emergencies, and other practical response skills for people who need a recognized non-healthcare-provider certification. First aid content is framed around fast recognition, EMS activation, and practical action while help is on the way. Choking response follows the current pattern: adults and children receive 5 back blows and 5 abdominal thrusts; infants receive 5 back blows and 5 chest thrusts. Opioid emergency content highlights recognition, naloxone availability, CPR with breaths for respiratory arrest, and why hands-only CPR may not be enough. Stroke content uses FAST recognition, urgent EMS activation, and avoids treating stroke as an older-adult-only problem. Seizure response focuses on protecting from injury, not restraining the person, placing nothing in the mouth, and calling EMS for prolonged, repeated, first-time, injured, breathing-compromised, water-related, pregnant, diabetic, or pediatric febrile seizure concerns. Asthma support includes helping with the person's prescribed bronchodilator, using a spacer when available, and understanding that an improvised spacer may help when a standard spacer is not available. Environmental first aid includes rapid cooling for severe heat illness, ice water immersion when available, safe rewarming for cold exposure, and avoiding harmful warming methods. Additional first aid topics include ticks, stings, burns, eye injuries, poison ivy/oak exposure, and pulse oximetry limitations.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13870561",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -232,19 +224,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="/heartsaver.html" data-empty-link-label="See upcoming Heartsaver classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest Heartsaver class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13872968" data-start="2026-08-14T14:30:00-04:00" data-end="2026-08-14T17:00:00-04:00" data-session-start="2026-08-14T14:30:00-04:00">
   <div class="upcoming-date">August 14, 2026</div>
   <div class="upcoming-time">2:30 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13872968.html">Book This Class</a>
   </div>
@@ -254,7 +248,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">6:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13857862.html">Book This Class</a>
   </div>
@@ -267,10 +261,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for teachers, childcare staff, fitness professionals, security teams, office staff, church teams, construction crews, and other workplace responders.</p>
@@ -301,7 +305,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -320,7 +324,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13870561",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209809",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209809",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13870579.html
+++ b/docs/classes/13870579.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Monday Morning AHA BLS HeartCode Skills Session in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Monday Morning AHA BLS HeartCode Skills Session in Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 10, 2026 at 11:00 AM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13870579.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Monday Morning AHA BLS HeartCode Skills Session in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 10, 2026 at 11:00 AM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-10T11:00:00-04:00",
   "endDate": "2026-08-10T12:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 10, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider HeartCode skills session. Students complete the AHA online HeartCode BLS coursework first, then use this appointment for hands-on skills practice and testing. It is built for healthcare and clinical roles that need AHA BLS Provider certification while using the blended-learning pathway, including high-quality CPR, AED use, ventilation practice, choking response, and team communication. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13870579",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct210549" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
   <div class="upcoming-date">August 24, 2026</div>
   <div class="upcoming-time">9:45 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">11:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">1:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">9:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13895945" data-start="2026-08-10T15:00:00-04:00" data-end="2026-08-10T17:00:00-04:00" data-session-start="2026-08-10T15:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">3:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">12:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13847870" data-start="2026-08-14T10:00:00-04:00" data-end="2026-08-14T12:00:00-04:00" data-session-start="2026-08-14T10:00:00-04:00">
+  <div class="upcoming-date">August 14, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870445" data-start="2026-08-08T12:30:00-04:00" data-end="2026-08-08T14:30:00-04:00" data-session-start="2026-08-08T12:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">12:30 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13889121" data-start="2026-08-11T08:00:00-04:00" data-end="2026-08-11T10:00:00-04:00" data-session-start="2026-08-11T08:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">8:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13865036" data-start="2026-08-11T19:00:00-04:00" data-end="2026-08-11T21:00:00-04:00" data-session-start="2026-08-11T19:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">7:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13870579",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct210549",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct210549",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13872968.html
+++ b/docs/classes/13872968.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Friday Afternoon AHA Heartsaver Class in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="Friday Afternoon AHA Heartsaver Class in Wilmington NC | 910CPR">
 <meta property="og:description" content="Heartsaver session in Wilmington, NC on August 14, 2026 at 2:30 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13872968.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Friday Afternoon AHA Heartsaver Class in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="Heartsaver session in Wilmington, NC on August 14, 2026 at 2:30 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-14T14:30:00-04:00",
   "endDate": "2026-08-14T17:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "Heartsaver in Wilmington on August 14, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This AHA Heartsaver First Aid CPR AED class is for workplace, school, childcare, fitness, church, and community responders. It combines first aid, CPR, AED, choking, opioid emergency awareness, stroke recognition, seizure response, asthma assistance, burns, environmental emergencies, and other practical response skills for people who need a recognized non-healthcare-provider certification. First aid content is framed around fast recognition, EMS activation, and practical action while help is on the way. Choking response follows the current pattern: adults and children receive 5 back blows and 5 abdominal thrusts; infants receive 5 back blows and 5 chest thrusts. Opioid emergency content highlights recognition, naloxone availability, CPR with breaths for respiratory arrest, and why hands-only CPR may not be enough. Stroke content uses FAST recognition, urgent EMS activation, and avoids treating stroke as an older-adult-only problem. Seizure response focuses on protecting from injury, not restraining the person, placing nothing in the mouth, and calling EMS for prolonged, repeated, first-time, injured, breathing-compromised, water-related, pregnant, diabetic, or pediatric febrile seizure concerns. Asthma support includes helping with the person's prescribed bronchodilator, using a spacer when available, and understanding that an improvised spacer may help when a standard spacer is not available. Environmental first aid includes rapid cooling for severe heat illness, ice water immersion when available, safe rewarming for cold exposure, and avoiding harmful warming methods. Additional first aid topics include ticks, stings, burns, eye injuries, poison ivy/oak exposure, and pulse oximetry limitations.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13872968",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -232,19 +224,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="/heartsaver.html" data-empty-link-label="See upcoming Heartsaver classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest Heartsaver class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13870561" data-start="2026-08-14T12:00:00-04:00" data-end="2026-08-14T14:30:00-04:00" data-session-start="2026-08-14T12:00:00-04:00">
   <div class="upcoming-date">August 14, 2026</div>
   <div class="upcoming-time">12:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870561.html">Book This Class</a>
   </div>
@@ -254,7 +248,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">6:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13857862.html">Book This Class</a>
   </div>
@@ -267,10 +261,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13861222.html"><strong>AHA BLS Provider</strong><span>Next: Aug 8 at 10:30 AM</span></a></li><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13889121.html"><strong>AHA BLS Provider</strong><span>Next: Aug 11 at 8:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>Good fit for teachers, childcare staff, fitness professionals, security teams, office staff, church teams, construction crews, and other workplace responders.</p>
@@ -301,7 +305,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -320,7 +324,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13872968",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209809",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209809",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13882574.html
+++ b/docs/classes/13882574.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Thursday Afternoon AHA BLS Provider Course in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="Thursday Afternoon AHA BLS Provider Course in Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 13, 2026 at 12:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13882574.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Thursday Afternoon AHA BLS Provider Course in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 13, 2026 at 12:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-13T12:00:00-04:00",
   "endDate": "2026-08-13T14:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 13, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider course for healthcare providers and students entering clinical programs. The class covers high-quality CPR, AED use, ventilations, choking response, and team-based basic life support for adult, child, and infant patients. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13882574",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209806" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">10:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">11:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 14, 2026</div>
   <div class="upcoming-time">10:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">8:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">12:30 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13850189" data-start="2026-08-10T13:00:00-04:00" data-end="2026-08-10T15:00:00-04:00" data-session-start="2026-08-10T13:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">1:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13861222" data-start="2026-08-08T10:30:00-04:00" data-end="2026-08-08T12:30:00-04:00" data-session-start="2026-08-08T10:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">10:30 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13895945" data-start="2026-08-10T15:00:00-04:00" data-end="2026-08-10T17:00:00-04:00" data-session-start="2026-08-10T15:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">3:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13887884" data-start="2026-08-17T09:00:00-04:00" data-end="2026-08-17T11:00:00-04:00" data-session-start="2026-08-17T09:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">9:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13865036" data-start="2026-08-11T19:00:00-04:00" data-end="2026-08-11T21:00:00-04:00" data-session-start="2026-08-11T19:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">7:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13882574",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13887884.html
+++ b/docs/classes/13887884.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0002
 
-I keep the marker after the vessel has gone. A late traveler still deserves to know where the next safe passage begins.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>AHA BLS Renewal Course on Monday in Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ I keep the marker after the vessel has gone. A late traveler still deserves to k
 <meta property="og:title" content="AHA BLS Renewal Course on Monday in Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 17, 2026 at 9:00 AM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13887884.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AHA BLS Renewal Course on Monday in Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 17, 2026 at 9:00 AM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-17T09:00:00-04:00",
   "endDate": "2026-08-17T11:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 17, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider renewal class for students who already work at the healthcare-provider level and need to keep their BLS current. The class focuses on high-quality CPR, AED use, ventilations, choking response, and team response for adult, child, and infant emergencies. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13887884",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct359474" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13850189" data-start="2026-08-10T13:00:00-04:00" data-end="2026-08-10T15:00:00-04:00" data-session-start="2026-08-10T13:00:00-04:00">
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">1:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">3:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">12:30 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">7:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13889121" data-start="2026-08-11T08:00:00-04:00" data-end="2026-08-11T10:00:00-04:00" data-session-start="2026-08-11T08:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">8:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13888037" data-start="2026-08-17T11:00:00-04:00" data-end="2026-08-17T13:00:00-04:00" data-session-start="2026-08-17T11:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13847870" data-start="2026-08-14T10:00:00-04:00" data-end="2026-08-14T12:00:00-04:00" data-session-start="2026-08-14T10:00:00-04:00">
+  <div class="upcoming-date">August 14, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">12:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13887884",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13888037.html
+++ b/docs/classes/13888037.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0001
 
-A proper berth has a name, a time, and a clear way aboard. Anything less leaves good people pacing the quay.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Morning AHA BLS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ A proper berth has a name, a time, and a clear way aboard. Anything less leaves 
 <meta property="og:title" content="Morning AHA BLS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 17, 2026 at 11:00 AM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13888037.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Morning AHA BLS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 17, 2026 at 11:00 AM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-17T11:00:00-04:00",
   "endDate": "2026-08-17T13:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 17, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider course for healthcare providers and students entering clinical programs. The class covers high-quality CPR, AED use, ventilations, choking response, and team-based basic life support for adult, child, and infant patients. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13888037",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209806" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">10:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">12:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 14, 2026</div>
   <div class="upcoming-time">10:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">8:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">11:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13850189" data-start="2026-08-10T13:00:00-04:00" data-end="2026-08-10T15:00:00-04:00" data-session-start="2026-08-10T13:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">1:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13861222" data-start="2026-08-08T10:30:00-04:00" data-end="2026-08-08T12:30:00-04:00" data-session-start="2026-08-08T10:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">10:30 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13887884" data-start="2026-08-17T09:00:00-04:00" data-end="2026-08-17T11:00:00-04:00" data-session-start="2026-08-17T09:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">9:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13895945" data-start="2026-08-10T15:00:00-04:00" data-end="2026-08-10T17:00:00-04:00" data-session-start="2026-08-10T15:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">3:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870445" data-start="2026-08-08T12:30:00-04:00" data-end="2026-08-08T14:30:00-04:00" data-session-start="2026-08-08T12:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">12:30 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13865036" data-start="2026-08-11T19:00:00-04:00" data-end="2026-08-11T21:00:00-04:00" data-session-start="2026-08-11T19:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">7:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13888037",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13889121.html
+++ b/docs/classes/13889121.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Morning AHA BLS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Morning AHA BLS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 11, 2026 at 8:00 AM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13889121.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Morning AHA BLS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 11, 2026 at 8:00 AM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-11T08:00:00-04:00",
   "endDate": "2026-08-11T10:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 11, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider course for healthcare providers and students entering clinical programs. The class covers high-quality CPR, AED use, ventilations, choking response, and team-based basic life support for adult, child, and infant patients. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13889121",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209806" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">10:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 14, 2026</div>
   <div class="upcoming-time">10:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">11:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">12:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">7:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13887884" data-start="2026-08-17T09:00:00-04:00" data-end="2026-08-17T11:00:00-04:00" data-session-start="2026-08-17T09:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">9:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13861222" data-start="2026-08-08T10:30:00-04:00" data-end="2026-08-08T12:30:00-04:00" data-session-start="2026-08-08T10:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">10:30 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870445" data-start="2026-08-08T12:30:00-04:00" data-end="2026-08-08T14:30:00-04:00" data-session-start="2026-08-08T12:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">12:30 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13850189" data-start="2026-08-10T13:00:00-04:00" data-end="2026-08-10T15:00:00-04:00" data-session-start="2026-08-10T13:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">1:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13895945" data-start="2026-08-10T15:00:00-04:00" data-end="2026-08-10T17:00:00-04:00" data-session-start="2026-08-10T15:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">3:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13889121",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13895945.html
+++ b/docs/classes/13895945.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Afternoon AHA BLS Renewal Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Afternoon AHA BLS Renewal Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 10, 2026 at 3:00 PM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13895945.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Afternoon AHA BLS Renewal Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 10, 2026 at 3:00 PM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-10T15:00:00-04:00",
   "endDate": "2026-08-10T17:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 10, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider renewal class for students who already work at the healthcare-provider level and need to keep their BLS current. The class focuses on high-quality CPR, AED use, ventilations, choking response, and team response for adult, child, and infant emergencies. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13895945",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct359474" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13850189" data-start="2026-08-10T13:00:00-04:00" data-end="2026-08-10T15:00:00-04:00" data-session-start="2026-08-10T13:00:00-04:00">
   <div class="upcoming-date">August 10, 2026</div>
   <div class="upcoming-time">1:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">12:30 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">9:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">7:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13888037" data-start="2026-08-17T11:00:00-04:00" data-end="2026-08-17T13:00:00-04:00" data-session-start="2026-08-17T11:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">12:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13889121" data-start="2026-08-11T08:00:00-04:00" data-end="2026-08-11T10:00:00-04:00" data-session-start="2026-08-11T08:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">8:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13897109" data-start="2026-08-13T10:00:00-04:00" data-end="2026-08-13T12:00:00-04:00" data-session-start="2026-08-13T10:00:00-04:00">
+  <div class="upcoming-date">August 13, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13897109.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13847870" data-start="2026-08-14T10:00:00-04:00" data-end="2026-08-14T12:00:00-04:00" data-session-start="2026-08-14T10:00:00-04:00">
+  <div class="upcoming-date">August 14, 2026</div>
+  <div class="upcoming-time">10:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13895945",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct359474",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/classes/13897109.html
+++ b/docs/classes/13897109.html
@@ -1,14 +1,9 @@
-<!-- BUILD_CODE: 2026-08-07 20:00 | scripts/build_landers.py | D:\a\910cpr-class-landers\910cpr-class-landers\docs\data\schedule_future.json -->
+<!-- BUILD_CODE: 2026-08-07 23:57 | scripts/build_landers.py | C:\Users\ten77\Documents\Codex\2026-08-07\trace-the-bls-schedule-calculation-for\work\public-session-landers\docs\data\schedule_future.json -->
 <!DOCTYPE html>
-<!--
-Dockmaster’s Journal
-Entry 0003
 
-Once one passenger commits, the departure is real. Then the useful work is helping the others find it.
--->
 <html lang="en">
 <head>
-<meta name="build-date" content="2026-08-07T20:00:23-04:00">
+<meta name="build-date" content="2026-08-07T23:57:03-04:00">
 <meta charset="UTF-8">
 <title>Morning AHA BLS Provider Course - Wilmington NC | 910CPR</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -19,15 +14,15 @@ Once one passenger commits, the departure is real. Then the useful work is helpi
 <meta property="og:title" content="Morning AHA BLS Provider Course - Wilmington NC | 910CPR">
 <meta property="og:description" content="BLS session in Wilmington, NC on August 13, 2026 at 10:00 AM. View details and continue to secure registration with 910CPR.">
 <meta property="og:url" content="https://www.910cpr.com/classes/13897109.html">
-<meta property="og:image" content="https://www.910cpr.com/images/0aha.png">
+<meta property="og:image" content="https://www.910cpr.com/images/logo.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Morning AHA BLS Provider Course - Wilmington NC | 910CPR">
 <meta name="twitter:description" content="BLS session in Wilmington, NC on August 13, 2026 at 10:00 AM. View details and continue to secure registration with 910CPR.">
-<meta name="twitter:image" content="https://www.910cpr.com/images/0aha.png">
+<meta name="twitter:image" content="https://www.910cpr.com/images/logo.png">
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="/css/lander.css?v=20260808-session-discovery">
 <!-- Google Tag Manager -->
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -49,7 +44,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "eventStatus": "https://schema.org/EventScheduled",
   "startDate": "2026-08-13T10:00:00-04:00",
   "endDate": "2026-08-13T12:00:00-04:00",
-  "image": "https://www.910cpr.com/images/0aha.png",
   "description": "BLS in Wilmington on August 13, 2026. Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina. This is the American Heart Association BLS Provider course for healthcare providers and students entering clinical programs. The class covers high-quality CPR, AED use, ventilations, choking response, and team-based basic life support for adult, child, and infant patients. Current CPR and ECC training emphasizes high-quality compressions, AED use, ventilation when indicated, and clear team communication. For opioid-related respiratory arrest, hands-only CPR is not always enough. Training reinforces EMS activation, naloxone access when available, and CPR with breaths when breathing is absent or abnormal.",
   "performer": {
     "@type": "Organization",
@@ -76,7 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "url": "https://coastalcprtraining.enrollware.com/enroll?id=13897109",
     "availability": "https://schema.org/InStock",
     "priceCurrency": "USD",
-    "validFrom": "2026-08-07T20:00:23-04:00"
+    "validFrom": "2026-08-07T23:57:03-04:00"
   }
 }
 </script>
@@ -97,11 +91,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a class="site-header-phone" href="tel:+19103955193" aria-label="Call 910CPR at 910-395-5193">910-395-5193</a>
     </header>
 
-    
 
-    
 
-    
+
+
+
 
     <section class="hero">
 
@@ -118,10 +112,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="hero-side">
-        
-<div class="cert-badge">
-  <img src="/images/0aha.png" alt="Certifying body logo" loading="lazy">
-</div>
+
+<div class="cert-badge cert-badge-empty" aria-hidden="true"></div>
 
         <div class="trust-badge">
           <strong>Mapped course details</strong>
@@ -159,7 +151,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     </div>
 
-    
+
 <section class="confidence-block" aria-label="Course confidence">
   <div class="confidence-item">
     <span>Certifying body</span>
@@ -195,7 +187,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <p>Listed location: Wilmington; Shipyard Blvd - B.</p>
 </section>
 
-    
+
 <section class="trust-snippet" aria-label="Student review">
   <div class="trust-snippet-score">
     <span class="review-stars" aria-label="Five star review">★★★★★</span>
@@ -205,7 +197,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box course-description-priority">
   <h2>Course Description</h2>
   <div class="description-html">
@@ -215,7 +207,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+
 <section class="section-box guideline-update-section">
   <h2>Current Guideline Focus</h2>
   <p>910CPR keeps public course pages practical and class-first while aligning response language with current AHA, Red Cross, and certifying-agency first aid and CPR guidance.</p>
@@ -226,19 +218,21 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 </section>
 
 
-    
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="https://coastalcprtraining.enrollware.com/schedule#ct209806" data-empty-link-label="See upcoming BLS classes" data-full-schedule-link="/schedule.html">
   <div class="upcoming-head">
-    <h2>More upcoming dates</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <h2>Latest BLS class dates</h2>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
-    
+
 <div class="upcoming-card js-session-item" data-session-id="13882574" data-start="2026-08-13T12:00:00-04:00" data-end="2026-08-13T14:00:00-04:00" data-session-start="2026-08-13T12:00:00-04:00">
   <div class="upcoming-date">August 13, 2026</div>
   <div class="upcoming-time">12:00 PM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13882574.html">Book This Class</a>
   </div>
@@ -248,7 +242,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 14, 2026</div>
   <div class="upcoming-time">10:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13847870.html">Book This Class</a>
   </div>
@@ -258,7 +252,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 17, 2026</div>
   <div class="upcoming-time">11:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13888037.html">Book This Class</a>
   </div>
@@ -268,7 +262,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 11, 2026</div>
   <div class="upcoming-time">8:00 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13889121.html">Book This Class</a>
   </div>
@@ -278,9 +272,79 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="upcoming-date">August 08, 2026</div>
   <div class="upcoming-time">10:30 AM</div>
   <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
-  
+
   <div class="upcoming-actions">
     <a class="button small primary" href="/classes/13861222.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870579" data-start="2026-08-10T11:00:00-04:00" data-end="2026-08-10T12:00:00-04:00" data-session-start="2026-08-10T11:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">11:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870579.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13887884" data-start="2026-08-17T09:00:00-04:00" data-end="2026-08-17T11:00:00-04:00" data-session-start="2026-08-17T09:00:00-04:00">
+  <div class="upcoming-date">August 17, 2026</div>
+  <div class="upcoming-time">9:00 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13887884.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13870445" data-start="2026-08-08T12:30:00-04:00" data-end="2026-08-08T14:30:00-04:00" data-session-start="2026-08-08T12:30:00-04:00">
+  <div class="upcoming-date">August 08, 2026</div>
+  <div class="upcoming-time">12:30 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13870445.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13850189" data-start="2026-08-10T13:00:00-04:00" data-end="2026-08-10T15:00:00-04:00" data-session-start="2026-08-10T13:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">1:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13850189.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13852838" data-start="2026-08-24T09:45:00-04:00" data-end="2026-08-24T10:45:00-04:00" data-session-start="2026-08-24T09:45:00-04:00">
+  <div class="upcoming-date">August 24, 2026</div>
+  <div class="upcoming-time">9:45 AM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13852838.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13895945" data-start="2026-08-10T15:00:00-04:00" data-end="2026-08-10T17:00:00-04:00" data-session-start="2026-08-10T15:00:00-04:00">
+  <div class="upcoming-date">August 10, 2026</div>
+  <div class="upcoming-time">3:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13895945.html">Book This Class</a>
+  </div>
+</div>
+
+<div class="upcoming-card js-session-item" data-session-id="13865036" data-start="2026-08-11T19:00:00-04:00" data-end="2026-08-11T21:00:00-04:00" data-session-start="2026-08-11T19:00:00-04:00">
+  <div class="upcoming-date">August 11, 2026</div>
+  <div class="upcoming-time">7:00 PM</div>
+  <div class="upcoming-location">Wilmington; Shipyard Blvd - B</div>
+
+  <div class="upcoming-actions">
+    <a class="button small primary" href="/classes/13865036.html">Book This Class</a>
   </div>
 </div>
 
@@ -291,10 +355,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </section>
 
+      </div>
 
-    
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul><li><a href="/classes/13870579.html"><strong>AHA BLS HeartCode Skills Session</strong><span>Next: Aug 10 at 11:00 AM</span></a></li><li><a href="/classes/13828438.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828445.html"><strong>AHA ACLS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828454.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13828461.html"><strong>AHA PALS Provider</strong><span>Next: Aug 12 at 2:00 PM</span></a></li><li><a href="/classes/13870561.html"><strong>AHA Heartsaver First Aid CPR AED</strong><span>Next: Aug 14 at 12:00 PM</span></a></li></ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 
-    
+    </div>
+
+
+
+
 <section class="section-box">
   <h2>Who This Class Is For</h2>
   <p>This is the class most nursing, EMS, dental, hospital, and clinical programs mean when they ask for AHA BLS.</p>
@@ -325,7 +399,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     None
 
-    <div class="build-stamp">Build: 2026-08-07 20:00</div>
+    <div class="build-stamp">Build: 2026-08-07 23:57</div>
 
   </div>
 </div>
@@ -344,7 +418,7 @@ const pageContext = {
   register_url: "https://coastalcprtraining.enrollware.com/enroll?id=13897109",
   schedule_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
   course_page_url: "https://coastalcprtraining.enrollware.com/schedule#ct209806",
-  build_stamp: "2026-08-07 20:00"
+  build_stamp: "2026-08-07 23:57"
 };
 
 window.dataLayer.push({

--- a/docs/css/lander.css
+++ b/docs/css/lander.css
@@ -555,6 +555,65 @@ a {
   text-align: center;
 }
 
+.lander-discovery-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(250px, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.current-courses-sidebar {
+  position: sticky;
+  top: 18px;
+  margin-top: 18px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: linear-gradient(180deg, var(--medical-soft) 0%, #ffffff 100%);
+}
+
+.current-courses-sidebar h2 {
+  margin: 0;
+  color: var(--heading);
+  font-size: 21px;
+}
+
+.current-courses-sidebar > p {
+  margin: 7px 0 14px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.current-courses-sidebar ul {
+  display: grid;
+  gap: 9px;
+  margin: 0 0 15px;
+  padding: 0;
+  list-style: none;
+}
+
+.current-courses-sidebar li a {
+  display: grid;
+  gap: 3px;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #ffffff;
+  color: var(--heading);
+  text-decoration: none;
+}
+
+.current-courses-sidebar li a:hover {
+  border-color: var(--medical-dark);
+  box-shadow: var(--shadow-soft);
+}
+
+.current-courses-sidebar li span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .brand-strip {
   display: grid;
   grid-template-columns: 180px minmax(0, 1fr);
@@ -697,6 +756,14 @@ a {
   .upcoming-grid,
   .confidence-block {
     grid-template-columns: 1fr;
+  }
+
+  .lander-discovery-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .current-courses-sidebar {
+    position: static;
   }
 }
 

--- a/scripts/build_landers.py
+++ b/scripts/build_landers.py
@@ -44,7 +44,8 @@ REVIEWS_SOURCE = ROOT / "data" / "raw" / "reviews"
 COURSE_MAP_FILE = ROOT / "data" / "config" / "course_map.json"
 
 GTM_ID = "GTM-PQS8DCBH"
-UPCOMING_LIMIT = 10
+LANDER_CSS_URL = "/css/lander.css?v=20260808-session-discovery"
+UPCOMING_LIMIT = 12
 REVIEWS_PER_PAGE = 3
 MIN_REVIEW_LENGTH = 35
 ENTITY_IDENTITY = "Authorized American Heart Association Training Site providing CPR, BLS, ACLS, PALS & Heartsaver courses throughout Coastal North Carolina."
@@ -227,7 +228,7 @@ def load_sessions_from_file(path: Path) -> list[dict]:
         if not isinstance(item, dict) or not session_has_public_class_location(item):
             continue
         normalized = normalize_session_record(item)
-        if not is_public_direct_bookable_session(normalized):
+        if not is_session_lander_candidate(normalized):
             continue
         sessions.append(normalized)
     return sessions
@@ -249,6 +250,14 @@ def is_public_direct_bookable_session(session: dict) -> bool:
     if session.get("is_full") is True or str(session.get("is_full")).strip().lower() == "true":
         return False
     return verified_enrollware_url(enrollware_url_for_session(session))
+
+
+def is_session_lander_candidate(session: dict) -> bool:
+    """A seated class or an open public Enrollware session deserves a durable page."""
+    register_url = enrollware_url_for_session(session)
+    if not verified_enrollware_url(register_url):
+        return False
+    return session_enrolled_count(session) >= 1 or is_public_direct_bookable_session(session)
 
 
 def is_mapped(session: dict) -> bool:
@@ -437,7 +446,7 @@ def session_lander_status(session: dict, register_url: str, dt: datetime | None,
 
 
 def status_is_indexable(status: str, register_url: str) -> bool:
-    return status == "published_upcoming" and verified_enrollware_url(register_url)
+    return status in {"published_upcoming", "past_completed"} and verified_enrollware_url(register_url)
 
 
 def robots_for_lander_status(status: str, register_url: str) -> str:
@@ -1177,12 +1186,12 @@ def render_upcoming_sessions_html(upcoming_sessions: list[dict], course_url: str
 """
         )
 
-    heading = "More upcoming dates" if upcoming_sessions else "Need a different time?"
+    heading = f"Latest {course_label} class dates" if upcoming_sessions else "Need a different time?"
     return f"""
 <section id="upcoming-times" class="section-box js-live-session-group" data-empty-link="{escape(course_url)}" data-empty-link-label="{escape(primary_label)}" data-full-schedule-link="{escape(full_schedule_url)}">
   <div class="upcoming-head">
     <h2>{escape(heading)}</h2>
-    <p>These related future sessions link to their own class pages before registration.</p>
+    <p>Compare the newest currently bookable dates. Every listed session has its own class page and registration path.</p>
   </div>
   <div class="upcoming-grid">
     {''.join(cards)}
@@ -1192,6 +1201,56 @@ def render_upcoming_sessions_html(upcoming_sessions: list[dict], course_url: str
     <a class="text-link" href="{escape(full_schedule_url)}">See all 910CPR classes</a>
   </div>
 </section>
+"""
+
+
+def get_other_current_courses(current_session: dict, sessions: list[dict], now_dt: datetime) -> list[dict]:
+    """Return the next public session for every other currently offered course."""
+    current_course_id = str(current_session.get("course_id") or current_session.get("course_number") or "").strip()
+    current_name = display_course_name(current_session.get("course_name", "")).lower()
+    next_by_course: dict[str, dict] = {}
+
+    for session in sessions:
+        if not is_public_direct_bookable_session(session):
+            continue
+        dt = session.get("_parsed_dt") or parse_dt(session.get("start_at"))
+        if not is_future_session(dt, now_dt):
+            continue
+        course_id = str(session.get("course_id") or session.get("course_number") or "").strip()
+        course_name = display_course_name(session.get("course_name", ""))
+        if (current_course_id and course_id == current_course_id) or course_name.lower() == current_name:
+            continue
+        key = course_id or course_name.lower()
+        copy = dict(session)
+        copy["_parsed_dt"] = dt
+        existing = next_by_course.get(key)
+        if existing is None or dt < existing["_parsed_dt"]:
+            next_by_course[key] = copy
+
+    return sorted(next_by_course.values(), key=lambda item: (item["_parsed_dt"], display_course_name(item.get("course_name", "")).lower()))
+
+
+def render_current_courses_sidebar_html(current_courses: list[dict]) -> str:
+    if not current_courses:
+        return ""
+    links = []
+    for session in current_courses:
+        dt = session["_parsed_dt"]
+        sid = str(session.get("session_id") or "").strip()
+        course_name = display_course_name(session.get("course_name", ""))
+        links.append(
+            f'<li><a href="{escape(session_lander_url(sid), quote=True)}">'
+            f'<strong>{escape(course_name)}</strong>'
+            f'<span>Next: {escape(dt.strftime("%b %d at %I:%M %p").replace(" 0", " "))}</span>'
+            '</a></li>'
+        )
+    return f"""
+<aside class="current-courses-sidebar" aria-labelledby="current-courses-heading">
+  <h2 id="current-courses-heading">Other current courses</h2>
+  <p>Explore the next live session for every other course currently offered by 910CPR.</p>
+  <ul>{''.join(links)}</ul>
+  <a class="text-link strong-link" href="/schedule.html">View the complete class schedule</a>
+</aside>
 """
 
 
@@ -1432,7 +1491,7 @@ def render_retained_course_lander_page(
 <meta name="robots" content="noindex,follow">
 <link rel="canonical" href="{escape(canonical_url)}">
 <link rel="icon" type="image/png" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="{LANDER_CSS_URL}">
 {render_gtm_head()}
 </head>
 <body class="lander course-{short_slug(course_display)}">
@@ -2096,7 +2155,7 @@ TEMPLATE = """<!DOCTYPE html>
 <link rel="icon" type="image/png" href="/images/logo.png">
 <link rel="shortcut icon" href="/images/logo.png">
 <link rel="apple-touch-icon" href="/images/logo.png">
-<link rel="stylesheet" href="/css/lander.css">
+<link rel="stylesheet" href="{LANDER_CSS_URL}">
 {gtm_head}
 {schema_block}
 </head>
@@ -2183,7 +2242,12 @@ TEMPLATE = """<!DOCTYPE html>
 
     {guideline_update_section}
 
-    {upcoming_sessions_html}
+    <div class="lander-discovery-layout">
+      <div class="lander-latest-sessions">
+        {upcoming_sessions_html}
+      </div>
+      {current_courses_sidebar_html}
+    </div>
 
     {brand_strip_html}
 
@@ -2371,7 +2435,7 @@ def main() -> None:
     parser.add_argument(
         "--anchors-only",
         action="store_true",
-        help="Build only public sessions with a confirmed seat; preserve every existing historical page.",
+        help="Build every current public direct-bookable Enrollware session; preserve every existing historical page.",
     )
     parser.add_argument(
         "--data-file",
@@ -2401,7 +2465,9 @@ def main() -> None:
 
     canonical_sessions = load_sessions_from_file(data_file)
     if args.anchors_only:
-        canonical_sessions = [session for session in canonical_sessions if session_enrolled_count(session) >= 1]
+        # Kept for workflow compatibility: public Enrollware sessions are real
+        # lander anchors even before their first student registers.
+        canonical_sessions = [session for session in canonical_sessions if is_session_lander_candidate(session)]
     historical_sessions = []
     for source in (FULL_DATA_FILE, DEFAULT_DATA_FILE):
         if source.resolve() != data_file.resolve():
@@ -2650,15 +2716,14 @@ def main() -> None:
             session,
             sessions,
             now_dt,
-            limit=5,
+            limit=UPCOMING_LIMIT,
             future_index=future_replacement_index,
         )
-        if lander_status in {"past_completed", "published_closed", "proposed"} or retained_course_lander:
-            top_inventory_html = render_past_current_inventory_html(upcoming_sessions, type_page_url, course_label)
-            upcoming_sessions_html = ""
-        else:
-            top_inventory_html = ""
-            upcoming_sessions_html = render_upcoming_sessions_html(upcoming_sessions, type_page_url, course_label)
+        top_inventory_html = ""
+        upcoming_sessions_html = render_upcoming_sessions_html(upcoming_sessions, type_page_url, course_label)
+        current_courses_sidebar_html = render_current_courses_sidebar_html(
+            get_other_current_courses(session, canonical_sessions, now_dt)
+        )
 
         selected_reviews = pick_reviews_for_session(
             session_id=session_id,
@@ -2678,6 +2743,7 @@ def main() -> None:
         trust_badge_copy = same_day_note(session) or "Structured course metadata is shown before schedule alternatives."
 
         html_doc = TEMPLATE.format(
+            LANDER_CSS_URL=LANDER_CSS_URL,
             dockmaster_comment=dockmaster_comment(session_id),
             page_title=escape(page_title),
             meta_description=escape(meta_description),
@@ -2731,6 +2797,7 @@ def main() -> None:
             local_reference_html=local_reference_html,
             review_snippet_html=review_snippet_html,
             upcoming_sessions_html=upcoming_sessions_html,
+            current_courses_sidebar_html=current_courses_sidebar_html,
             brand_strip_html=brand_strip_html,
             reviews_html=reviews_html,
             course_description_section=course_description_section,
@@ -2749,6 +2816,7 @@ def main() -> None:
             course_page_url=escape(course_page_url),
         )
         html_doc = apply_build_metadata(html_doc, build_meta)
+        html_doc = "\n".join(line.rstrip() for line in html_doc.splitlines()) + "\n"
 
         if args.anchors_only and output_path.exists():
             existing_html = output_path.read_text(encoding="utf-8", errors="ignore")

--- a/tests/test_public_css_references.py
+++ b/tests/test_public_css_references.py
@@ -29,14 +29,14 @@ class PublicCssReferenceTests(unittest.TestCase):
             for match in LANDER_REFERENCE.finditer(path.read_text(encoding="utf-8", errors="replace")):
                 references.append((path, match.group(1)))
         self.assertGreater(len(references), 0)
-        failures = [f"{path.relative_to(ROOT)} -> {reference}" for path, reference in references if reference != "/css/lander.css"]
+        failures = [f"{path.relative_to(ROOT)} -> {reference}" for path, reference in references if not reference.startswith("/css/lander.css")]
         self.assertEqual([], failures, "Nonstandard public stylesheet references:\n" + "\n".join(failures))
 
     def test_generators_never_emit_relative_lander_reference(self) -> None:
         failures: list[str] = []
         for path in sorted((ROOT / "scripts").rglob("*.py")):
             for match in LANDER_REFERENCE.finditer(path.read_text(encoding="utf-8", errors="replace")):
-                if match.group(1) != "/css/lander.css":
+                if not match.group(1).startswith("/css/lander.css"):
                     failures.append(f"{path.relative_to(ROOT)} -> {match.group(1)}")
         self.assertEqual([], failures, "Generators emitting nonstandard stylesheet references:\n" + "\n".join(failures))
 

--- a/tests/test_public_session_landers.py
+++ b/tests/test_public_session_landers.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timedelta
+import unittest
+
+from scripts import build_landers
+
+
+class PublicSessionLanderTests(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2026, 8, 7, 12, 0, tzinfo=build_landers.TZ)
+
+    def session(self, session_id, course_id, course_name, days=1, enrolled=0):
+        return {
+            "session_id": str(session_id),
+            "course_id": str(course_id),
+            "course_name": course_name,
+            "start_at": (self.now + timedelta(days=days)).isoformat(),
+            "session_status": "published",
+            "registration_status": "open",
+            "registration_url": f"https://coastalcprtraining.enrollware.com/enroll?id={session_id}",
+            "enrolled_count": enrolled,
+        }
+
+    def test_zero_enrollment_public_session_is_direct_bookable(self):
+        self.assertTrue(build_landers.is_public_direct_bookable_session(self.session(101, 1, "AHA BLS Provider")))
+        self.assertTrue(build_landers.is_session_lander_candidate(self.session(101, 1, "AHA BLS Provider")))
+
+    def test_seated_closed_session_still_gets_a_durable_lander(self):
+        session = self.session(101, 1, "AHA BLS Provider", enrolled=1)
+        session["registration_status"] = "full"
+        session["is_full"] = True
+        self.assertFalse(build_landers.is_public_direct_bookable_session(session))
+        self.assertTrue(build_landers.is_session_lander_candidate(session))
+
+    def test_past_real_session_remains_indexable(self):
+        session = self.session(101, 1, "AHA BLS Provider", days=-1)
+        register_url = session["registration_url"]
+        status = build_landers.session_lander_status(session, register_url, build_landers.parse_dt(session["start_at"]), self.now)
+        self.assertEqual("past_completed", status)
+        self.assertEqual("index,follow", build_landers.robots_for_lander_status(status, register_url))
+
+    def test_sidebar_has_one_next_session_for_every_other_current_course(self):
+        current = self.session(101, 1, "AHA BLS Provider")
+        sessions = [
+            current,
+            self.session(102, 1, "AHA BLS Provider", days=2),
+            self.session(201, 2, "AHA ACLS Provider", days=4),
+            self.session(202, 2, "AHA ACLS Provider", days=3),
+            self.session(301, 3, "AHA PALS Provider", days=5),
+        ]
+        other = build_landers.get_other_current_courses(current, sessions, self.now)
+        self.assertEqual(["202", "301"], [row["session_id"] for row in other])
+        html = build_landers.render_current_courses_sidebar_html(other)
+        self.assertIn('/classes/202.html', html)
+        self.assertIn('/classes/301.html', html)
+        self.assertNotIn('/classes/201.html', html)
+        self.assertNotIn('/classes/102.html', html)
+
+    def test_class_templates_cache_bust_the_changed_stylesheet(self):
+        self.assertIn('href="{LANDER_CSS_URL}"', build_landers.TEMPLATE)
+        self.assertIn("?v=", build_landers.LANDER_CSS_URL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- generate a durable lander for every seated class or current public direct-bookable Enrollware session
- keep real passed-session URLs indexable and pivot them to current dates
- expand same-course latest-session links to 12
- add a responsive sidebar linking the next session for every other current course
- cache-bust the updated shared lander stylesheet

## Validation
- 5 focused lander behavior tests passed
- 3 stylesheet-reference checks passed
- 40/40 generated public landers passed canonical, robots, date, time, CTA, latest-list, sidebar, and stylesheet checks
- 40/40 current generated landers are present in sitemap.xml